### PR TITLE
Use github releases to download a specific initial version

### DIFF
--- a/x86_64/Dockerfile
+++ b/x86_64/Dockerfile
@@ -11,10 +11,12 @@ RUN add-apt-repository "deb http://apt.llvm.org/jessie/ llvm-toolchain-jessie-4.
  && apt-get update \
  && apt-get install -y llvm-4.0-dev
 
-ARG previous_crystal_release_url
-RUN mkdir -p /tmp/crystal \
- && curl -sSL ${previous_crystal_release_url} | tar xz -C /tmp/crystal --strip-component=1
+ARG previous_crystal_release
+ADD ${previous_crystal_release} /tmp/crystal.tar.gz
 ENV PATH=${PATH}:/tmp/crystal/bin
+RUN mkdir -p /tmp/crystal \
+ && tar xz -f /tmp/crystal.tar.gz -C /tmp/crystal --strip-component=1 \
+ && crystal --version
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"

--- a/x86_64/Dockerfile
+++ b/x86_64/Dockerfile
@@ -8,10 +8,13 @@ RUN apt-get update \
 
 RUN add-apt-repository "deb http://apt.llvm.org/jessie/ llvm-toolchain-jessie-4.0 main" \
  && curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && add-apt-repository "deb https://dist.crystal-lang.org/apt crystal main" \
- && apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54 \
  && apt-get update \
- && apt-get install -y llvm-4.0-dev crystal
+ && apt-get install -y llvm-4.0-dev
+
+ARG previous_crystal_release_url
+RUN mkdir -p /tmp/crystal \
+ && curl -sSL ${previous_crystal_release_url} | tar xz -C /tmp/crystal --strip-component=1
+ENV PATH=${PATH}:/tmp/crystal/bin
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"

--- a/x86_64/Makefile
+++ b/x86_64/Makefile
@@ -11,10 +11,10 @@ no_cache ?=    ## Disable the docker build cache
 pull_images ?= ## Always pull docker images to ensure they're up to date
 release ?=     ## Create an optimized build for the final release
 
-PREVIOUS_CRYSTAL_RELEASE_URL = https://github.com/crystal-lang/crystal/releases/download/0.23.1/crystal-0.23.1-3-linux-x86_64.tar.gz
 CRYSTAL_VERSION = 0.24.1
 PACKAGE_ITERATION = 1
 SHARDS_VERSION = v0.7.2
+PREVIOUS_CRYSTAL_RELEASE = https://github.com/crystal-lang/crystal/releases/download/0.23.1/crystal-0.23.1-3-linux-x86_64.tar.gz
 
 GC_VERSION = v7.4.6
 LIBATOMIC_OPS_VERSION = v7.4.8
@@ -28,7 +28,7 @@ FILES = files/crystal-wrapper files/ysbaddaden.pub
 DEB_NAME = crystal_$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)_amd64.deb
 RPM_NAME = crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).x86_64.rpm
 
-BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )$(if $(release),--build-arg release=true )--build-arg crystal_version=$(CRYSTAL_VERSION) --build-arg shards_version=$(SHARDS_VERSION) --build-arg gc_version=$(GC_VERSION) --build-arg libatomic_ops_version=$(LIBATOMIC_OPS_VERSION) --build-arg libevent_version=$(LIBEVENT_VERSION) --build-arg previous_crystal_release_url=$(PREVIOUS_CRYSTAL_RELEASE_URL)
+BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )$(if $(release),--build-arg release=true )--build-arg crystal_version=$(CRYSTAL_VERSION) --build-arg shards_version=$(SHARDS_VERSION) --build-arg gc_version=$(GC_VERSION) --build-arg libatomic_ops_version=$(LIBATOMIC_OPS_VERSION) --build-arg libevent_version=$(LIBEVENT_VERSION) --build-arg previous_crystal_release=$(PREVIOUS_CRYSTAL_RELEASE)
 
 .PHONY: all
 all: compress package ## Build compressed omnibus and distribution packages [default]

--- a/x86_64/Makefile
+++ b/x86_64/Makefile
@@ -11,6 +11,7 @@ no_cache ?=    ## Disable the docker build cache
 pull_images ?= ## Always pull docker images to ensure they're up to date
 release ?=     ## Create an optimized build for the final release
 
+PREVIOUS_CRYSTAL_RELEASE_URL = https://github.com/crystal-lang/crystal/releases/download/0.23.1/crystal-0.23.1-3-linux-x86_64.tar.gz
 CRYSTAL_VERSION = 0.24.1
 PACKAGE_ITERATION = 1
 SHARDS_VERSION = v0.7.2
@@ -27,7 +28,7 @@ FILES = files/crystal-wrapper files/ysbaddaden.pub
 DEB_NAME = crystal_$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)_amd64.deb
 RPM_NAME = crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).x86_64.rpm
 
-BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )$(if $(release),--build-arg release=true )--build-arg crystal_version=$(CRYSTAL_VERSION) --build-arg shards_version=$(SHARDS_VERSION) --build-arg gc_version=$(GC_VERSION) --build-arg libatomic_ops_version=$(LIBATOMIC_OPS_VERSION) --build-arg libevent_version=$(LIBEVENT_VERSION)
+BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )$(if $(release),--build-arg release=true )--build-arg crystal_version=$(CRYSTAL_VERSION) --build-arg shards_version=$(SHARDS_VERSION) --build-arg gc_version=$(GC_VERSION) --build-arg libatomic_ops_version=$(LIBATOMIC_OPS_VERSION) --build-arg libevent_version=$(LIBEVENT_VERSION) --build-arg previous_crystal_release_url=$(PREVIOUS_CRYSTAL_RELEASE_URL)
 
 .PHONY: all
 all: compress package ## Build compressed omnibus and distribution packages [default]


### PR DESCRIPTION
I made a PR to download the binary from github directly. This way it does not depends on which is the stable crystal package published in debian.