### PR TITLE
Always use https protocol for dependencies fetched from GitHub

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
+  "https://github.com/#{repo_name}.git"
+end
+
 gem 'omnibus', '~> 5.5.0'
 gem 'omnibus-software', github: 'chef/omnibus-software'


### PR DESCRIPTION
Will silence warnings like:

>The git source `git://github.com/XXX/YYY.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.

See https://github.com/bundler/bundler/blob/1e8ce587798edcc75f72cb89eea5a2a425bb579c/lib/bundler/dsl.rb#L277-L289