### PR TITLE
Fix Gemfile in order to keep omnibus 5.5.0 compatible gems

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -6,4 +6,4 @@ git_source(:github) do |repo_name|
 end
 
 gem 'omnibus', '~> 5.5.0'
-gem 'omnibus-software', github: 'chef/omnibus-software'
+gem 'omnibus-software', github: 'chef/omnibus-software', ref: '91d716b2f88127e0b1f742b98c63e18119498af3'

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: git://github.com/chef/omnibus-software.git
+  remote: https://github.com/chef/omnibus-software.git
   revision: 91d716b2f88127e0b1f742b98c63e18119498af3
+  ref: 91d716b2f88127e0b1f742b98c63e18119498af3
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)


### PR DESCRIPTION
Since #6 started to be used for nightly builds the osx build was failing https://circleci.com/gh/crystal-lang/crystal/5719

This changes fixed that https://circleci.com/gh/crystal-lang/crystal/5760.

The alternative would be to rollback #6.

@Sija it seems that when the PR was sent the `bundle` command was not run to update the Gemfile.lock

It's a bit ugly that revision and ref is present in Gemfile.lock, but it seems to be the bundler way.