### PR TITLE
Remove --no-ri --no-rdoc options

### DIFF
--- a/linux/Dockerfile-fpm
+++ b/linux/Dockerfile-fpm
@@ -6,4 +6,4 @@ RUN apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV PATH="/usr/local/bundle/bin/:${PATH}"
-RUN gem install --no-ri --no-rdoc fpm -v 1.10.2
+RUN gem install --no-document fpm -v 1.10.2


### PR DESCRIPTION
Rubygems 3 is out and shipped in ruby:2.4/2.5 docker images by default.

Rubygems 3 does no longer support --no-ri --no-rdoc options and nightly builds are failing.
After this PR an update in crystal will be needed and we can include the latest changes also.