### PR TITLE
Add ldd output and wait before touch

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -90,12 +90,10 @@ RUN git clone https://github.com/crystal-lang/crystal \
  && git checkout ${crystal_sha1} \
  \
  && make deps \
- && mkdir .build \
- && cc '/crystal-musl.o' -o '.build/crystal' -rdynamic src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags` -lstdc++ -lpcre -lm -lgc -lpthread src/ext/libcrystal.a -levent -lrt \
- && ldd .build/crystal \
- && sleep 2 \
+ && mkdir -p .build/crystal-musl \
+ && cc '/crystal-musl.o' -o '.build/crystal-musl/crystal' -rdynamic src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags` -lstdc++ -lpcre -lm -lgc -lpthread src/ext/libcrystal.a -levent -lrt \
+ && export PATH=.build/crystal-musl/:$PATH \
  \
- && touch src/compiler/crystal.cr \
  && make crystal stats=true static=true ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} \
  && ldd .build/crystal

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -96,7 +96,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  \
  && make crystal stats=true static=true ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} \
- && ldd .build/crystal
+ && (if [[ $(ldd .build/crystal | wc -l) -gt "1" ]]; then echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; fi)
 
 # Build shards
 ARG shards_version

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -92,10 +92,13 @@ RUN git clone https://github.com/crystal-lang/crystal \
  && make deps \
  && mkdir .build \
  && cc '/crystal-musl.o' -o '.build/crystal' -rdynamic src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags` -lstdc++ -lpcre -lm -lgc -lpthread src/ext/libcrystal.a -levent -lrt \
+ && ldd .build/crystal \
+ && sleep 2 \
  \
  && touch src/compiler/crystal.cr \
  && make crystal stats=true static=true ${release:+release=true} \
-                 CRYSTAL_CONFIG_TARGET=${gnu_target}
+                 CRYSTAL_CONFIG_TARGET=${gnu_target} \
+ && ldd .build/crystal
 
 # Build shards
 ARG shards_version

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -96,7 +96,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  \
  && make crystal stats=true static=true ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} \
- && (if [[ $(ldd .build/crystal | wc -l) -gt "1" ]]; then echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; fi)
+ && ([ "$(ldd .build/crystal | wc -l)" -eq "1" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
 
 # Build shards
 ARG shards_version


### PR DESCRIPTION
Related to #33 .

Sometimes the touch leave the same date as the cc output. The sleep should fix that.
I added ldd output to have some additional manual checks during the build.

I'm not sure if this will solve 100% of the issues, but it reduces the chances and the logs have additional diagnosis information.

Maintenance build at https://circleci.com/workflow-run/e2779fd7-c51c-4b53-9e61-a36db574e779