### PR TITLE
Add snap target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ darwin/build/
 
 snapcraft/snap/snapcraft.yaml
 snapcraft/*.snap
+snapcraft/build/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ omnibus/crystal-darwin-x86_64
 docs/build/
 
 darwin/build/
+
+snapcraft/snap/snapcraft.yaml
+snapcraft/*.snap

--- a/snapcraft/Makefile
+++ b/snapcraft/Makefile
@@ -1,6 +1,10 @@
+OUTPUT_DIR = build
+
 .PHONY: all
 all: snap/snapcraft.yaml
+	mkdir -p $(OUTPUT_DIR)
 	snapcraft
+	mv *.snap $(OUTPUT_DIR)
 
 .PHONY: snap/snapcraft.yaml
 snap/snapcraft.yaml:
@@ -8,3 +12,4 @@ snap/snapcraft.yaml:
 
 clean:
 	rm snap/snapcraft.yaml
+	rm -Rf $(OUTPUT_DIR)

--- a/snapcraft/Makefile
+++ b/snapcraft/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+all: snap/snapcraft.yaml
+	snapcraft
+
+.PHONY: snap/snapcraft.yaml
+snap/snapcraft.yaml:
+	sed 's/$${CRYSTAL_RELEASE_LINUX64_TARGZ}/$(subst /,\/,$(CRYSTAL_RELEASE_LINUX64_TARGZ))/; s/$${SNAP_GRADE}/$(SNAP_GRADE)/' snap/local/snapcraft.yaml.tpl > snap/snapcraft.yaml
+
+clean:
+	rm snap/snapcraft.yaml

--- a/snapcraft/README.md
+++ b/snapcraft/README.md
@@ -1,5 +1,7 @@
 # snap for Crystal
 
+https://snapcraft.io/crystal
+
 ## Dependencies
 
 - [`snapcraft`](https://docs.snapcraft.io/snapcraft-overview)
@@ -31,8 +33,7 @@ $ SNAP_GRADE=devel CRYSTAL_RELEASE_LINUX64_TARGZ="https://github.com/crystal-lan
 
 2.
     ```
-    $ sudo snap install --classic crystal
-    $ sudo snap alias crystal.shards shards
+    $ sudo snap install crystal --classic
     ```
 
 ## Post-Install

--- a/snapcraft/README.md
+++ b/snapcraft/README.md
@@ -1,0 +1,51 @@
+# snap for Crystal
+
+## Dependencies
+
+- [`snapcraft`](https://docs.snapcraft.io/snapcraft-overview)
+
+## Build the snap
+
+Define the configuration variables and use `make` to expand the `./snap/local/snapcraft.yaml.tpl`.
+
+```sh
+$ SNAP_GRADE=devel CRYSTAL_RELEASE_LINUX64_TARGZ="https://github.com/crystal-lang/crystal/releases/download/0.29.0/crystal-0.29.0-1-linux-x86_64.tar.gz" make
+```
+
+## Snap channels usage
+
+| Build             | Channel                    | Version   | Comments                                             |
+|-------------------|----------------------------|-----------|------------------------------------------------------|
+| tagged release    | latest/edge                | M.m.p     | manual set to beta, candidate, stable upon release   |
+| nighties release  | latest/edge                | M.m.p-dev |                                                      |
+| maintenance build | latest/edge/${branch-name} | M.m.p-dev |                                                      |
+
+### Configuration
+
+* `CRYSTAL_RELEASE_LINUX64_TARGZ`: Url to crystal-{version}-{package}-linux-x86_64.tar.gz
+* `SNAP_GRADE`: Snap grande usually `devel` for nightlies and `stable` for tagged releases
+
+## Install the snap
+
+1. [Have snapd installed](https://snapcraft.io/docs/core/install)
+
+2.
+    ```
+    $ sudo snap install --classic crystal
+    $ sudo snap alias crystal.shards shards
+    ```
+
+## Post-Install
+
+This snap ships the compiler, all required native libraries should be available on the host.
+
+The following are the suggested packages to be able to use the whole standard library capabilities.
+
+```
+$ sudo apt-get install gcc pkg-config git tzdata \
+                       libpcre3-dev libevent-dev libyaml-dev \
+                       libgmp-dev libssl-dev libxml2-dev
+```
+
+You can find more detailed information in the [Crystal reference](https://crystal-lang.org/reference/installation/on_debian_and_ubuntu.html) and in the [Crystal wiki](https://github.com/crystal-lang/crystal/wiki/All-required-libraries) if you want to be able to build the compiler itself.
+

--- a/snapcraft/crystal-snap-wrapper
+++ b/snapcraft/crystal-snap-wrapper
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+if [ ! -f $SNAP_USER_COMMON/env-check-success ]; then
+  # check if a simple program can be compiled
+  # if something fails show a banner to the user
+
+  $SNAP/bin/crystal eval 'puts "1"' >/dev/null 2>/dev/null
+  if [ $? -eq 0 ]; then
+    touch $SNAP_USER_COMMON/env-check-success
+  else
+    cat <<EOF
+
+  It seems that some libraries are missing in your host.
+  The following are the suggested packages to be able to use the whole standard library capabilities.
+
+    $ sudo apt-get install gcc pkg-config git tzdata \\
+                           libpcre3-dev libevent-dev libyaml-dev \\
+                           libgmp-dev libssl-dev libxml2-dev
+
+  You can find more detailed information in:
+
+    * https://crystal-lang.org/reference/installation/on_debian_and_ubuntu.html
+    * https://github.com/crystal-lang/crystal/wiki/All-required-libraries
+
+EOF
+
+  fi
+fi
+
+exec $SNAP/bin/crystal "$@"

--- a/snapcraft/snap/local/snapcraft.yaml.tpl
+++ b/snapcraft/snap/local/snapcraft.yaml.tpl
@@ -1,0 +1,30 @@
+name: crystal
+base: core
+summary: A language for humans and computers
+description: |
+  * Have a syntax similar to Ruby (but compatibility with it is not a goal)
+  * Statically type-checked but without having to specify the type of variables or method arguments.
+  * Be able to call C code by writing bindings to it in Crystal.
+  * Have compile-time evaluation and generation of code, to avoid boilerplate code. Compile to efficient native code.
+adopt-info: crystal
+
+grade: ${SNAP_GRADE}
+confinement: classic
+
+environment:
+  SHARDS_CACHE_PATH: $SNAP_USER_COMMON/.cache/shards
+  CRYSTAL_CACHE_DIR: $SNAP_USER_COMMON/.cache/crystal
+
+apps:
+  crystal:
+    command: bin/crystal
+  shards:
+    command: bin/shards
+
+parts:
+  crystal:
+    plugin: dump
+    source: ${CRYSTAL_RELEASE_LINUX64_TARGZ}
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(cat $SNAPCRAFT_PART_SRC/share/crystal/src/VERSION | head -n 1)"

--- a/snapcraft/snap/local/snapcraft.yaml.tpl
+++ b/snapcraft/snap/local/snapcraft.yaml.tpl
@@ -17,7 +17,7 @@ environment:
 
 apps:
   crystal:
-    command: bin/crystal
+    command: crystal-snap-wrapper
   shards:
     command: bin/shards
 
@@ -28,3 +28,9 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(cat $SNAPCRAFT_PART_SRC/share/crystal/src/VERSION | head -n 1)"
+
+  snap-wrapper:
+    plugin: dump
+    source: .
+    stage:
+      - crystal-snap-wrapper


### PR DESCRIPTION
The maintenance and tagged builds are already stressed in 

* https://circleci.com/workflow-run/88f4c4a1-7360-4b71-84ff-5cd19e7fb6d0
* https://circleci.com/workflow-run/9a38150d-836b-4a10-9f9e-8c9b0e442478

This will be used to ship nightly builds to snap.

The snap is built by embedding a known tar.gz that can be a url or a local path