### PR TITLE
Build LLVM in CI and upgrade to llvm 6.0.1 in omnibus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2
+
+jobs:
+  omnibus_osx_llvm:
+    macos:
+      xcode: "9.0"
+    environment:
+      LLVM_VERSION: 6.0.1
+      MACOSX_DEPLOYMENT_TARGET: 10.11
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - run:
+          name: Setup environment
+          command: |
+            brew update
+            brew install pkgconfig libtool cmake
+
+            sudo mkdir -p /opt/llvm
+            sudo chown $(whoami) /opt/llvm/
+            sudo mkdir -p /var/cache
+            sudo chown $(whoami) /var/cache
+      - checkout
+      - run:
+          no_output_timeout: 140m
+          name: Build LLVM
+          command: |
+            cd omnibus
+            bundle check || bundle install --binstubs
+            bundle exec omnibus build llvm
+      - store_artifacts:
+          path: ./omnibus/pkg
+          destination: llvm
+
+workflows:
+  version: 2
+
+  build_llvm:
+    jobs:
+      - omnibus_osx_llvm:
+          filters:
+            branches:
+              only:
+                - /.*\bbuild-llvm\b.*/

--- a/omnibus/config/software/llvm.rb
+++ b/omnibus/config/software/llvm.rb
@@ -1,5 +1,5 @@
 name "llvm"
-LLVM_VERSION = (ENV['LLVM_VERSION'] || "3.9.1").strip
+LLVM_VERSION = (ENV['LLVM_VERSION'] || "6.0.1").strip
 default_version LLVM_VERSION
 
 source url: "http://releases.llvm.org/#{version}/llvm-#{version}.src.tar.xz"

--- a/omnibus/config/software/llvm.rb
+++ b/omnibus/config/software/llvm.rb
@@ -1,8 +1,16 @@
 name "llvm"
-default_version "3.9.1"
+LLVM_VERSION = (ENV['LLVM_VERSION'] || "3.9.1").strip
+default_version LLVM_VERSION
 
-source :url => "http://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz",
-       :md5 => "3259018a7437e157f3642df80f1983ea"
+source url: "http://releases.llvm.org/#{version}/llvm-#{version}.src.tar.xz"
+
+version "3.9.1" do
+  source md5: "3259018a7437e157f3642df80f1983ea"
+end
+
+version "6.0.1" do
+  source md5: "c88c98709300ce2c285391f387fecce0"
+end
 
 relative_path "llvm-#{version}.src"
 

--- a/omnibus/config/software/llvm_bin.rb
+++ b/omnibus/config/software/llvm_bin.rb
@@ -1,14 +1,25 @@
 name "llvm_bin"
-default_version "3.9.1-1"
+LLVM_VERSION = (ENV['LLVM_VERSION'] || "3.9.1").strip
+default_version "#{LLVM_VERSION}-1"
 
 if linux?
-  if _64_bit?
-    source_md5 = "cedaa626e3959b5ab467467e6dfb91fe"
+  case LLVM_VERSION
+  when "3.9.1"
+    if _64_bit?
+      source_md5 = "cedaa626e3959b5ab467467e6dfb91fe"
+    else
+      source_md5 = "8b847e903163054196d3854122363b8b"
+    end
   else
-    source_md5 = "8b847e903163054196d3854122363b8b"
+    raise "llvm_bin #{LLVM_VERSION} not supported on linux"
   end
 elsif mac_os_x? && _64_bit?
-  source_md5 = "9fb52b6a648e700f431b459586eb5403"
+  case LLVM_VERSION
+  when "3.9.1"
+    source_md5 = "9fb52b6a648e700f431b459586eb5403"
+  else
+    raise "llvm_bin #{LLVM_VERSION} not supported on osx"
+  end
 end
 
 source url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-#{version}-#{ohai['os']}-#{ohai['kernel']['machine']}.tar.gz",

--- a/omnibus/config/software/llvm_bin.rb
+++ b/omnibus/config/software/llvm_bin.rb
@@ -1,5 +1,5 @@
 name "llvm_bin"
-LLVM_VERSION = (ENV['LLVM_VERSION'] || "3.9.1").strip
+LLVM_VERSION = (ENV['LLVM_VERSION'] || "6.0.1").strip
 default_version "#{LLVM_VERSION}-1"
 
 if linux?
@@ -17,6 +17,8 @@ elsif mac_os_x? && _64_bit?
   case LLVM_VERSION
   when "3.9.1"
     source_md5 = "9fb52b6a648e700f431b459586eb5403"
+  when "6.0.1"
+    source_md5 = "435beaff5e309921f4d87c275cad4e03"
   else
     raise "llvm_bin #{LLVM_VERSION} not supported on osx"
   end


### PR DESCRIPTION
This PR allow to trigger the build a llvm package in CircleCI.
The output is manually stored in S3 where the llvm_bin package downloads it.

It will also allow shipping a crystal compiler using llvm 6.0.1 instead of 3.9.1.

After some testing, we could upgrade to newer llvm versions and even bump the one used in the linux packages. But all that is for the future.