### PR TITLE
Build linux compiler and shards without debug info

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -96,6 +96,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  \
  && make crystal stats=true static=true ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} \
+                 FLAGS="--no-debug" \
  && ([ "$(ldd .build/crystal | wc -l)" -eq "1" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
 
 # Build shards
@@ -108,7 +109,7 @@ RUN git clone https://github.com/crystal-lang/shards \
  # Hack to make shards not segfault
  && echo 'require "llvm/lib_llvm"; require "llvm/enums"; require "./src/shards"' > hack.cr \
  && /crystal/bin/crystal build --stats --target ${musl_target} \
-    hack.cr -o shards --static ${release:+--release}
+    hack.cr -o shards --static --no-debug ${release:+--release}
 
 COPY files/crystal-wrapper /output/bin/crystal
 COPY --from=debian /bdwgc/.libs/libgc.a /libgc-debian.a


### PR DESCRIPTION
darwin omnibus and homebrew formula compiles the compiler and shards with --no-debug

The CI have been failing lately because due to latest changes somehow seems to hit during the release process in the second stage of the compiler. It seems we are hitting https://github.com/crystal-lang/crystal/issues/4276

One of the exception seems to be https://github.com/crystal-lang/crystal/pull/7334/files#r250621065 from the trace of [a build with dprintf]( https://circleci.com/gh/crystal-lang/crystal/28301) and usually the errors in the last couple of days was looks like https://circleci.com/gh/crystal-lang/crystal/28075 .

Until that is solved, this workaround seems to allow the release to keep going.

A maintenance workflow was run at https://circleci.com/workflow-run/c1b9154b-cbb0-4041-ae6b-c7c00709153d

I also tried bumping all dependencies alpine:3.10, debian:9, llvm 8 as an alternative but the error was still there and even with debug information the stack trace seems to have less information https://circleci.com/gh/crystal-lang/crystal/28278

Bonus: there seems that a lot of exceptions are been raised while the compiler is been compiled. That can be viewed at https://circleci.com/gh/crystal-lang/crystal/28301 . Maybe there is something to improve there or to investigate to narrow the issue.

Somehow I couldn't reproduce the issue from Docker in OSX. And bisecting in the CI didn't offer real information to narrow it down.