### PR TITLE
Add targets to build docker images for 32 bits with nightly .deb

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:xenial as runtime
+ARG base_docker_image
+FROM ${base_docker_image} as runtime
 
 RUN \
   apt-get update && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,10 +4,14 @@ DOCKER_TAG ?=        ## How to tag the docker image. a -build will be appended f
 DOCKER_REPOSITORY ?= ## Docker hub repository to commit image
 
 OUTPUT_DIR = build
-BUILD_ARGS = --build-arg crystal_deb=./tmp/crystal.deb
+BUILD_ARGS64 = --build-arg crystal_deb=./tmp/crystal.deb --build-arg base_docker_image=ubuntu:xenial
+BUILD_ARGS32 = --build-arg crystal_deb=./tmp/crystal.deb --build-arg base_docker_image=i386/ubuntu:xenial
 
-.PHONY: all
-all: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-build.tar.gz
+.PHONY: all64
+all64: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-build.tar.gz
+
+.PHONY: all32
+all32: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386-build.tar.gz
 
 $(CURDIR)/tmp/crystal.deb:
 	mkdir -p $(CURDIR)/tmp
@@ -15,13 +19,23 @@ $(CURDIR)/tmp/crystal.deb:
 
 $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz: $(CURDIR)/tmp/crystal.deb
 	mkdir -p $(OUTPUT_DIR)
-	docker build $(BUILD_ARGS) --target runtime -t $(DOCKER_REPOSITORY):$(DOCKER_TAG) .
+	docker build $(BUILD_ARGS64) --target runtime -t $(DOCKER_REPOSITORY):$(DOCKER_TAG) .
 	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG) | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz
 
 $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-build.tar.gz: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz
 	mkdir -p $(OUTPUT_DIR)
-	docker build $(BUILD_ARGS) --target build -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-build .
+	docker build $(BUILD_ARGS64) --target build -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-build .
 	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-build | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-build.tar.gz
+
+$(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz: $(CURDIR)/tmp/crystal.deb
+	mkdir -p $(OUTPUT_DIR)
+	docker build $(BUILD_ARGS32) --target runtime -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386 .
+	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386 | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz
+
+$(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386-build.tar.gz: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz
+	mkdir -p $(OUTPUT_DIR)
+	docker build $(BUILD_ARGS32) --target build -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386-build .
+	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386-build | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386-build.tar.gz
 
 .PHONY: clean
 clean: ## Clean up build directory


### PR DESCRIPTION
Allow parametrized base image for docker image.
Can be used to run the recent compiler before releasing it in the CI.