### PR TITLE
Enhance Makefiles

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,27 +15,27 @@ all32: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz $(OUTPUT_DIR)/docker-
 
 $(CURDIR)/tmp/crystal.deb:
 	mkdir -p $(CURDIR)/tmp
-	cp $(CRYSTAL_DEB) $(CURDIR)/tmp/crystal.deb
+	cp $(CRYSTAL_DEB) $@
 
 $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz: $(CURDIR)/tmp/crystal.deb
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS64) --target runtime -t $(DOCKER_REPOSITORY):$(DOCKER_TAG) .
-	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG) | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz
+	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG) | gzip > $@
 
 $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-build.tar.gz: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION).tar.gz
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS64) --target build -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-build .
-	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-build | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-build.tar.gz
+	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-build | gzip > $@
 
 $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz: $(CURDIR)/tmp/crystal.deb
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS32) --target runtime -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386 .
-	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386 | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz
+	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386 | gzip > $@
 
 $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386-build.tar.gz: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386.tar.gz
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS32) --target build -t $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386-build .
-	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386-build | gzip > $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-i386-build.tar.gz
+	docker save $(DOCKER_REPOSITORY):$(DOCKER_TAG)-i386-build | gzip > $@
 
 .PHONY: clean
 clean: ## Clean up build directory

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -96,6 +96,9 @@ help: ## Show this help
 .PHONY: build
 build: $(OUTPUT_BASENAME64).tar ## Build the raw uncompressed tarball
 
+.PHONY: build32
+build32: $(OUTPUT_BASENAME32).tar ## Build the raw uncompressed tarball
+
 $(OUTPUT_BASENAME64).tar: Dockerfile $(FILES)
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS64) -t crystal-build-temp .
@@ -103,8 +106,18 @@ $(OUTPUT_BASENAME64).tar: Dockerfile $(FILES)
 	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
 	  && docker rm -v "$$container_id"
 
+$(OUTPUT_BASENAME32).tar: Dockerfile $(FILES)
+	mkdir -p $(OUTPUT_DIR)
+	docker build $(BUILD_ARGS32) -t crystal-build32-temp .
+	container_id="$$(docker create crystal-build32-temp)" \
+		&& docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
+		&& docker rm -v "$$container_id"
+
 .PHONY: compress64
 compress64: $(OUTPUT_BASENAME64).tar.gz $(OUTPUT_BASENAME64).tar.xz ## Build compressed tarballs
+
+.PHONY: compress32
+compress32: $(OUTPUT_BASENAME32).tar.gz $(OUTPUT_BASENAME32).tar.xz ## Build compressed tarballs
 
 $(OUTPUT_BASENAME64).tar.gz $(OUTPUT_BASENAME32).tar.gz: %.gz: %
 	gzip -c $^ > $@
@@ -114,6 +127,9 @@ $(OUTPUT_BASENAME64).tar.xz $(OUTPUT_BASENAME32).tar.xz: %.xz: %
 
 .PHONY: package64
 package64: $(OUTPUT_DIR)/$(DEB_NAME64) $(OUTPUT_DIR)/$(RPM_NAME64) ## Build distribution packages from the tarballs
+
+.PHONY: package32
+package32: $(OUTPUT_DIR)/$(DEB_NAME32) $(OUTPUT_DIR)/$(RPM_NAME32) ## Build distribution packages from the tarballs
 
 .PHONY: docker-fpm
 docker-fpm: Dockerfile-fpm
@@ -135,34 +151,6 @@ $(OUTPUT_DIR)/$(DEB_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
 		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
 		       $(FPM_FLAGS) bin lib share"
 
-$(OUTPUT_DIR)/$(RPM_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
-	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-		mkdir -p /tmp/crystal \
-		&& tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
-		&& fpm --input-type dir --output-type rpm \
-		       --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
-		       --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-		       --force --package $@ \
-		       --prefix /usr \
-		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-		       $(FPM_FLAGS) bin lib share"
-
-.PHONY: build32
-build32: $(OUTPUT_BASENAME32).tar ## Build the raw uncompressed tarball
-
-$(OUTPUT_BASENAME32).tar: Dockerfile $(FILES)
-	mkdir -p $(OUTPUT_DIR)
-	docker build $(BUILD_ARGS32) -t crystal-build32-temp .
-	container_id="$$(docker create crystal-build32-temp)" \
-		&& docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
-		&& docker rm -v "$$container_id"
-
-.PHONY: compress32
-compress32: $(OUTPUT_BASENAME32).tar.gz $(OUTPUT_BASENAME32).tar.xz ## Build compressed tarballs
-
-.PHONY: package32
-package32: $(OUTPUT_DIR)/$(DEB_NAME32) $(OUTPUT_DIR)/$(RPM_NAME32) ## Build distribution packages from the tarballs
-
 $(OUTPUT_DIR)/$(DEB_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
 	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
 		mkdir -p /tmp/crystal \
@@ -174,6 +162,18 @@ $(OUTPUT_DIR)/$(DEB_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
 		       --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
 		       --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
 		       --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
+		       --force --package $@ \
+		       --prefix /usr \
+		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
+		       $(FPM_FLAGS) bin lib share"
+
+$(OUTPUT_DIR)/$(RPM_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
+	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
+		mkdir -p /tmp/crystal \
+		&& tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
+		&& fpm --input-type dir --output-type rpm \
+		       --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
+		       --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
 		       --force --package $@ \
 		       --prefix /usr \
 		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -91,7 +91,7 @@ help: ## Show this help
 	@echo
 	@printf '\033[34mrecipes:\033[0m\n'
 	@grep -hE '^##.*$$' $(MAKEFILE_LIST) |\
-awk 'BEGIN {FS = "## "}; /^## [a-zA-Z_-]/ {printf "  \033[36m%s\033[0m\n", $$2}; /^##  / {printf "  %s\n", $$2}'
+		awk 'BEGIN {FS = "## "}; /^## [a-zA-Z_-]/ {printf "  \033[36m%s\033[0m\n", $$2}; /^##  / {printf "  %s\n", $$2}'
 
 .PHONY: build
 build: $(OUTPUT_BASENAME64).tar ## Build the raw uncompressed tarball
@@ -121,31 +121,31 @@ docker-fpm: Dockerfile-fpm
 
 $(OUTPUT_DIR)/$(DEB_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
 	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
-    && mv /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/licenses/crystal/LICENSE /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/doc/crystal/copyright \
-    && rm -Rf /tmp/crystal/crystal-*/share/licenses \
-    && fpm --input-type dir --output-type deb \
-           --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
-           --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
-           --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
-           --force --package $@ \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
+		mkdir -p /tmp/crystal \
+		&& tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
+		&& mv /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/licenses/crystal/LICENSE /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/doc/crystal/copyright \
+		&& rm -Rf /tmp/crystal/crystal-*/share/licenses \
+		&& fpm --input-type dir --output-type deb \
+		       --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
+		       --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
+		       --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
+		       --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
+		       --force --package $@ \
+		       --prefix /usr \
+		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
+		       $(FPM_FLAGS) bin lib share"
 
 $(OUTPUT_DIR)/$(RPM_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
 	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
-    && fpm --input-type dir --output-type rpm \
-           --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-           --force --package $@ \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
+		mkdir -p /tmp/crystal \
+		&& tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
+		&& fpm --input-type dir --output-type rpm \
+		       --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
+		       --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
+		       --force --package $@ \
+		       --prefix /usr \
+		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
+		       $(FPM_FLAGS) bin lib share"
 
 .PHONY: build32
 build32: $(OUTPUT_BASENAME32).tar ## Build the raw uncompressed tarball
@@ -154,8 +154,8 @@ $(OUTPUT_BASENAME32).tar: Dockerfile $(FILES)
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS32) -t crystal-build32-temp .
 	container_id="$$(docker create crystal-build32-temp)" \
-	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
-	  && docker rm -v "$$container_id"
+		&& docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
+		&& docker rm -v "$$container_id"
 
 .PHONY: compress32
 compress32: $(OUTPUT_BASENAME32).tar.gz $(OUTPUT_BASENAME32).tar.xz ## Build compressed tarballs
@@ -165,31 +165,31 @@ package32: $(OUTPUT_DIR)/$(DEB_NAME32) $(OUTPUT_DIR)/$(RPM_NAME32) ## Build dist
 
 $(OUTPUT_DIR)/$(DEB_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
 	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME32).tar \
-    && mv /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/licenses/crystal/LICENSE /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/doc/crystal/copyright \
-    && rm -Rf /tmp/crystal/crystal-*/share/licenses \
-    && fpm --input-type dir --output-type deb \
-           --architecture i386 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
-           --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
-           --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
-           --force --package $@ \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
+		mkdir -p /tmp/crystal \
+		&& tar -C /tmp/crystal -xf $(OUTPUT_BASENAME32).tar \
+		&& mv /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/licenses/crystal/LICENSE /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/doc/crystal/copyright \
+		&& rm -Rf /tmp/crystal/crystal-*/share/licenses \
+		&& fpm --input-type dir --output-type deb \
+		       --architecture i386 $(PACKAGE_BRANDING_ARGS) \
+		       --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
+		       --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
+		       --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
+		       --force --package $@ \
+		       --prefix /usr \
+		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
+		       $(FPM_FLAGS) bin lib share"
 
 $(OUTPUT_DIR)/$(RPM_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
 	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME32).tar \
-    && fpm --input-type dir --output-type rpm \
-           --architecture i386 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-           --force --package $@ \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
+		mkdir -p /tmp/crystal \
+		&& tar -C /tmp/crystal -xf $(OUTPUT_BASENAME32).tar \
+		&& fpm --input-type dir --output-type rpm \
+		       --architecture i386 $(PACKAGE_BRANDING_ARGS) \
+		       --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
+		       --force --package $@ \
+		       --prefix /usr \
+		       --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
+		       $(FPM_FLAGS) bin lib share"
 
 .PHONY: clean
 clean: ## Clean up build directory

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -100,24 +100,24 @@ $(OUTPUT_BASENAME64).tar: Dockerfile $(FILES)
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS64) -t crystal-build-temp .
 	container_id="$$(docker create crystal-build-temp)" \
-	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $(OUTPUT_BASENAME64).tar \
+	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
 	  && docker rm -v "$$container_id"
 
 .PHONY: compress64
 compress64: $(OUTPUT_BASENAME64).tar.gz $(OUTPUT_BASENAME64).tar.xz ## Build compressed tarballs
 
-$(OUTPUT_BASENAME64).tar.gz: $(OUTPUT_BASENAME64).tar
-	gzip -c $(OUTPUT_BASENAME64).tar > $(OUTPUT_BASENAME64).tar.gz
+$(OUTPUT_BASENAME64).tar.gz $(OUTPUT_BASENAME32).tar.gz: %.gz: %
+	gzip -c $^ > $@
 
-$(OUTPUT_BASENAME64).tar.xz: $(OUTPUT_BASENAME64).tar
-	xz -T 0 -c $(OUTPUT_BASENAME64).tar > $(OUTPUT_BASENAME64).tar.xz
+$(OUTPUT_BASENAME64).tar.xz $(OUTPUT_BASENAME32).tar.xz: %.xz: %
+	xz -T 0 -c $^ > $@
 
 .PHONY: package64
 package64: $(OUTPUT_DIR)/$(DEB_NAME64) $(OUTPUT_DIR)/$(RPM_NAME64) ## Build distribution packages from the tarballs
 
 .PHONY: docker-fpm
 docker-fpm: Dockerfile-fpm
-	docker build $(DOCKER_BUILD_ARGS) -t crystal-fpm -f Dockerfile-fpm .
+	docker build $(DOCKER_BUILD_ARGS) -t crystal-fpm -f $^ .
 
 $(OUTPUT_DIR)/$(DEB_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
 	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
@@ -130,7 +130,7 @@ $(OUTPUT_DIR)/$(DEB_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
            --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
            --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
            --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
-           --force --package $(OUTPUT_DIR)/$(DEB_NAME64) \
+           --force --package $@ \
            --prefix /usr \
            --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
            $(FPM_FLAGS) bin lib share"
@@ -142,7 +142,7 @@ $(OUTPUT_DIR)/$(RPM_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
     && fpm --input-type dir --output-type rpm \
            --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
            --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-           --force --package $(OUTPUT_DIR)/$(RPM_NAME64) \
+           --force --package $@ \
            --prefix /usr \
            --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
            $(FPM_FLAGS) bin lib share"
@@ -154,17 +154,11 @@ $(OUTPUT_BASENAME32).tar: Dockerfile $(FILES)
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS32) -t crystal-build32-temp .
 	container_id="$$(docker create crystal-build32-temp)" \
-	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $(OUTPUT_BASENAME32).tar \
+	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
 	  && docker rm -v "$$container_id"
 
 .PHONY: compress32
 compress32: $(OUTPUT_BASENAME32).tar.gz $(OUTPUT_BASENAME32).tar.xz ## Build compressed tarballs
-
-$(OUTPUT_BASENAME32).tar.gz: $(OUTPUT_BASENAME32).tar
-	gzip -c $(OUTPUT_BASENAME32).tar > $(OUTPUT_BASENAME32).tar.gz
-
-$(OUTPUT_BASENAME32).tar.xz: $(OUTPUT_BASENAME32).tar
-	xz -T 0 -c $(OUTPUT_BASENAME32).tar > $(OUTPUT_BASENAME32).tar.xz
 
 .PHONY: package32
 package32: $(OUTPUT_DIR)/$(DEB_NAME32) $(OUTPUT_DIR)/$(RPM_NAME32) ## Build distribution packages from the tarballs
@@ -180,7 +174,7 @@ $(OUTPUT_DIR)/$(DEB_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
            --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
            --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
            --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
-           --force --package $(OUTPUT_DIR)/$(DEB_NAME32) \
+           --force --package $@ \
            --prefix /usr \
            --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
            $(FPM_FLAGS) bin lib share"
@@ -192,7 +186,7 @@ $(OUTPUT_DIR)/$(RPM_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
     && fpm --input-type dir --output-type rpm \
            --architecture i386 $(PACKAGE_BRANDING_ARGS) \
            --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-           --force --package $(OUTPUT_DIR)/$(RPM_NAME32) \
+           --force --package $@ \
            --prefix /usr \
            --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
            $(FPM_FLAGS) bin lib share"

--- a/snapcraft/Makefile
+++ b/snapcraft/Makefile
@@ -8,7 +8,7 @@ all: snap/snapcraft.yaml
 
 .PHONY: snap/snapcraft.yaml
 snap/snapcraft.yaml:
-	sed 's/$${CRYSTAL_RELEASE_LINUX64_TARGZ}/$(subst /,\/,$(CRYSTAL_RELEASE_LINUX64_TARGZ))/; s/$${SNAP_GRADE}/$(SNAP_GRADE)/' snap/local/snapcraft.yaml.tpl > snap/snapcraft.yaml
+	sed 's/$${CRYSTAL_RELEASE_LINUX64_TARGZ}/$(subst /,\/,$(CRYSTAL_RELEASE_LINUX64_TARGZ))/; s/$${SNAP_GRADE}/$(SNAP_GRADE)/' snap/local/snapcraft.yaml.tpl > $@
 
 clean:
 	rm snap/snapcraft.yaml


### PR DESCRIPTION
This PR replaces the duplicate references to the targets and prerequisites with magic variables and reworks the Linux Makefile to handle 32 vs 64 bit dynamically where possible. Some targets were rearranged in the interest of keeping similars together.

I did not attempt handling targets with 32/64 in the variable names as this would have required variable changes and quite a bit of conditionals, though it could be handled.

Feedback highly encouraged.

E: Targets tested to be the same through --dry-run