### PR TITLE
Fix APK packages in alpine.Dockerfile

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.11 as runtime
 RUN \
   apk add --update --no-cache --force-overwrite \
     # core dependencies
-    gc-dev gcc gmp-dev libatomic_ops libevent-dev musl-dev pcre-dev \
+    gc-dev gcc gmp-dev libatomic_ops libevent-static musl-dev pcre-dev \
     # stdlib dependencies
-    libxml2-dev openssl-dev tzdata yaml-dev zlib-dev \
+    libxml2-dev openssl-libs-static tzdata yaml-dev zlib-static \
     # dev tools
     make git
 

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -5,7 +5,7 @@ RUN \
     # core dependencies
     gc-dev gcc gmp-dev libatomic_ops libevent-dev musl-dev pcre-dev \
     # stdlib dependencies
-    libxml2-dev openssl-dev readline-dev tzdata yaml-dev zlib-dev \
+    libxml2-dev openssl-dev tzdata yaml-dev zlib-dev \
     # dev tools
     make git
 

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -21,7 +21,7 @@ FROM runtime as build
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm-8 libedit-dev libreadline-dev gdb && \
+  apt-get install -y build-essential llvm-8 libedit-dev gdb && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV LIBRARY_PATH=/usr/lib/crystal/lib/


### PR DESCRIPTION
* Remove `readline-dev` because `Readline` has been removed from stdlib since Crystal 0.32.0
* Use proper packages providing `libevent`, `openssl` and `zlib` static libraries. (`*-static` packages also install `*-dev` packages