### PR TITLE
Fix apk static packages in alpine.Dockerfile

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.11 as runtime
 RUN \
   apk add --update --no-cache --force-overwrite \
     # core dependencies
-    gc-dev gcc gmp-dev libatomic_ops libevent-dev musl-dev pcre-dev \
+    gc-dev gcc gmp-dev libatomic_ops libevent-static musl-dev pcre-dev \
     # stdlib dependencies
-    libxml2-dev openssl-dev readline-dev tzdata yaml-dev zlib-dev \
+    libxml2-dev openssl-dev openssl-libs-static readline-dev tzdata yaml-dev zlib-static \
     # dev tools
     make git
 


### PR DESCRIPTION
Use proper packages providing libevent, openssl and zlib static libraries.
The *-static packages usually also install *-dev packages (except openssl-libs-static).

Followup to #29