### PR TITLE
Use clang-8 to build linux libgc and libcrystal

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -4,11 +4,12 @@ FROM ${debian_image} AS debian
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list \
  && apt-get update \
- && apt-get install -y -t buster-backports build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-8 \
+ && apt-get install -y -t buster-backports build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-8 clang-8 \
  && (pkg-config || true)
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
+ENV CC="clang-8"
 
 # Build libgc
 ARG gc_version


### PR DESCRIPTION
@RX14 do you have any reason to not include this change proposed in the referenced issue?

Fixes https://github.com/crystal-lang/crystal/issues/8653

It fix the 

```
libgc.a(alloc.o): unrecognized relocation (0x2a) in section `.text'
``` 

issue for me locally
