### PR TITLE
Update to shards 0.10.0

### DIFF
--- a/darwin/Makefile
+++ b/darwin/Makefile
@@ -43,8 +43,10 @@ darwin-previous: $(CURDIR)/../omnibus/crystal-darwin-x86_64 ## download previous
 $(CURDIR)/../omnibus/crystal-darwin-x86_64:
 	curl -L -o /tmp/crystal-darwin-x86_64.tar.gz $(PREVIOUS_CRYSTAL_RELEASE_DARWIN_TARGZ) \
 	&& tar xfz /tmp/crystal-darwin-x86_64.tar.gz -O "crystal-*/embedded/bin/crystal" > $(CURDIR)/../omnibus/crystal-darwin-x86_64 \
+	&& tar xfz /tmp/crystal-darwin-x86_64.tar.gz -O "crystal-*/embedded/bin/shards" > $(CURDIR)/../omnibus/shards-darwin-x86_64 \
 	&& rm /tmp/crystal-darwin-x86_64.tar.gz \
-	&& chmod +x $(CURDIR)/../omnibus/crystal-darwin-x86_64
+	&& chmod +x $(CURDIR)/../omnibus/crystal-darwin-x86_64 \
+	&& chmod +x $(CURDIR)/../omnibus/shards-darwin-x86_64
 
 $(OUTPUT_DIR)/$(DARWIN_NAME) $(OUTPUT_DIR)/$(DARWIN_PKG_NAME): ## Build omnibus crystal project
 ifeq ($(FORCE_GIT_TAGGED), 0)

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -21,8 +21,10 @@ FROM runtime as build
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm-8 libedit-dev gdb && \
+  apt-get install -y build-essential llvm-8 lld-8 libedit-dev gdb && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN ln -sf /usr/bin/ld.lld-8 /usr/bin/ld.lld
 
 ENV LIBRARY_PATH=/usr/lib/crystal/lib/
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -73,7 +73,8 @@ ADD ${previous_crystal_release} /tmp/crystal.tar.gz
 ENV PATH=${PATH}:/tmp/crystal/lib/crystal/bin/
 RUN mkdir -p /tmp/crystal \
   && tar xz -f /tmp/crystal.tar.gz -C /tmp/crystal --strip-component=1 \
-  && crystal --version
+  && crystal --version \
+  && shards --version
 
 # Build crystal
 ARG crystal_version
@@ -93,11 +94,13 @@ ARG musl_target
 RUN git clone https://github.com/crystal-lang/shards \
  && cd shards \
  && git checkout ${shards_version} \
+ && shards install --production \
  \
  # Hack to make shards not segfault
  && echo 'require "llvm/lib_llvm"; require "llvm/enums"; require "./src/shards"' > hack.cr \
  && /crystal/bin/crystal build --stats --target ${musl_target} \
-    hack.cr -o shards --static ${release:+--release}
+    hack.cr -o shards --static ${release:+--release} \
+ && ([ "$(ldd shards | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd shards; exit 1; })
 
 COPY files/crystal-wrapper /output/bin/crystal
 COPY --from=debian /bdwgc/.libs/libgc.a /libgc-debian.a

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -19,7 +19,7 @@ PACKAGE_MAINTAINER = Crystal Team <crystal@manas.tech>
 PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ ?=  ## url to crystal-{version}-{package}-linux-x86_64.tar.gz
 PREVIOUS_CRYSTAL_RELEASE_LINUX32_TARGZ ?=  ## url to crystal-{version}-{package}-linux-i686.tar.gz
 
-SHARDS_VERSION = v0.8.1
+SHARDS_VERSION = v0.10.0
 GC_VERSION = v8.0.4
 LIBATOMIC_OPS_VERSION = v7.6.10
 

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -1,4 +1,4 @@
-SHARDS_VERSION = "0.8.1"
+SHARDS_VERSION = "0.10.0"
 
 name "shards"
 default_version SHARDS_VERSION
@@ -18,12 +18,18 @@ version "0.8.1" do
   source md5: "f5b5108d798b1d86d2b9b45c3a2b5293"
 end
 
+version "0.10.0" do
+  source md5: "f982f2dc0c796763205bd0de68e9f87e"
+end
+
 source url: "https://github.com/crystal-lang/shards/archive/v#{version}.tar.gz"
 
 relative_path "shards-#{version}"
 env = with_standard_compiler_flags(with_embedded_path)
 
 build do
+  command "#{Dir.pwd}/shards-#{ohai['os']}-#{ohai['kernel']['machine']} install --production", env: env
+
   command "#{install_dir}/bin/crystal" \
           " build" \
           " -o #{install_dir}/embedded/bin/shards" \


### PR DESCRIPTION
* add check that is statically linked in linux
* install dependencies using previous crystal shards binary
* lld is also included in nightly images to match tagged releases as of crystal-lang/crystal-dist#8