### PR TITLE
Update CRYSTAL_PATH to allow .crystal/shards

### DIFF
--- a/linux/files/crystal-wrapper
+++ b/linux/files/crystal-wrapper
@@ -97,7 +97,7 @@ _canonicalize_file_path() {
 SCRIPT_DIR="$(dirname "$(realpath "$0" || echo "$0")")"
 ROOT_DIR="$SCRIPT_DIR/.."
 
-export CRYSTAL_PATH="${CRYSTAL_PATH:-"lib:$ROOT_DIR/share/crystal/src"}"
+export CRYSTAL_PATH="${CRYSTAL_PATH:-".crystal/shards:lib:$ROOT_DIR/share/crystal/src"}"
 export PATH="$ROOT_DIR/lib/crystal/bin:$PATH"
 export LIBRARY_PATH="$ROOT_DIR/lib/crystal/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$ROOT_DIR/lib/crystal/lib"

--- a/omnibus/config/templates/crystal/crystal.erb
+++ b/omnibus/config/templates/crystal/crystal.erb
@@ -96,7 +96,7 @@ _canonicalize_file_path() {
 
 SCRIPT_PATH="$(dirname "$(realpath "$0" || echo $0)")"
 INSTALL_DIR="$(realpath "$SCRIPT_PATH/..")"
-export CRYSTAL_PATH=${CRYSTAL_PATH:-"lib:$INSTALL_DIR/src"}
+export CRYSTAL_PATH=${CRYSTAL_PATH:-".crystal/shards:lib:$INSTALL_DIR/src"}
 export PATH="$INSTALL_DIR/embedded/bin:$PATH"
 export LIBRARY_PATH="$INSTALL_DIR/embedded/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$INSTALL_DIR/embedded/lib"


### PR DESCRIPTION
We need to keep :lib: for a couple of releases as a migration path.

Depends on https://github.com/crystal-lang/shards/pull/367