### PR TITLE
Update ubuntu64 Dockerfile to Focal Fossa (20.04 LTS) and LLVM 10

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@ DOCKER_REPOSITORY ?= ## Docker hub repository to commit image
 
 OUTPUT_DIR := build
 BUILD_CONTEXT := $(CURDIR)/build-context
-BUILD_ARGS_UBUNTU64 := --build-arg crystal_deb=crystal.deb $(BUILD_CONTEXT)/ubuntu64 --build-arg base_docker_image=ubuntu:bionic
+BUILD_ARGS_UBUNTU64 := --build-arg crystal_deb=crystal.deb $(BUILD_CONTEXT)/ubuntu64 --build-arg base_docker_image=ubuntu:focal
 BUILD_ARGS_UBUNTU32 := --build-arg crystal_deb=crystal.deb $(BUILD_CONTEXT)/ubuntu32 --build-arg base_docker_image=i386/ubuntu:bionic
 BUILD_ARGS_ALPINE := --build-arg crystal_targz=crystal.tar.gz $(BUILD_CONTEXT)/alpine
 DOCKER_TAG_UBUNTU := $(DOCKER_REPOSITORY):$(DOCKER_TAG)
@@ -45,8 +45,8 @@ alpine: ## Build alpine images
 alpine: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-alpine.tar.gz
 alpine: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-alpine-build.tar.gz
 
-$(BUILD_CONTEXT)/ubuntu32: ubuntu.Dockerfile $(BUILD_CONTEXT)/ubuntu32/crystal.deb
-	cp ubuntu.Dockerfile $@/Dockerfile
+$(BUILD_CONTEXT)/ubuntu32: ubuntu32.Dockerfile $(BUILD_CONTEXT)/ubuntu32/crystal.deb
+	cp ubuntu32.Dockerfile $@/Dockerfile
 
 $(BUILD_CONTEXT)/ubuntu64: ubuntu.Dockerfile $(BUILD_CONTEXT)/ubuntu64/crystal.deb
 	cp ubuntu.Dockerfile $@/Dockerfile

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -45,13 +45,13 @@ alpine: ## Build alpine images
 alpine: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-alpine.tar.gz
 alpine: $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-alpine-build.tar.gz
 
-$(BUILD_CONTEXT)/ubuntu32: $(BUILD_CONTEXT)/ubuntu32/crystal.deb
+$(BUILD_CONTEXT)/ubuntu32: ubuntu.Dockerfile $(BUILD_CONTEXT)/ubuntu32/crystal.deb
 	cp ubuntu.Dockerfile $@/Dockerfile
 
-$(BUILD_CONTEXT)/ubuntu64: $(BUILD_CONTEXT)/ubuntu64/crystal.deb
+$(BUILD_CONTEXT)/ubuntu64: ubuntu.Dockerfile $(BUILD_CONTEXT)/ubuntu64/crystal.deb
 	cp ubuntu.Dockerfile $@/Dockerfile
 
-$(BUILD_CONTEXT)/alpine: $(BUILD_CONTEXT)/alpine/crystal.tar.gz
+$(BUILD_CONTEXT)/alpine: alpine.Dockerfile $(BUILD_CONTEXT)/alpine/crystal.tar.gz
 	cp alpine.Dockerfile $@/Dockerfile
 
 %/crystal.deb:

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -31,6 +31,6 @@ FROM runtime as build
 
 RUN \
   apk add --update --no-cache --force-overwrite \
-    llvm10-dev llvmi10-static g++
+    llvm10-dev llvm10-static g++
 
 CMD ["/bin/sh"]

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as runtime
+FROM alpine:3.12 as runtime
 
 RUN \
   apk add --update --no-cache --force-overwrite \
@@ -31,6 +31,6 @@ FROM runtime as build
 
 RUN \
   apk add --update --no-cache --force-overwrite \
-    llvm-dev llvm-static g++
+    llvm10-dev llvmi10-static g++
 
 CMD ["/bin/sh"]

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y tzdata gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make \
-                     libpcre3-dev libevent-dev && \
+                     libpcre3-dev libevent-dev libz-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG crystal_deb

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -21,9 +21,9 @@ FROM runtime as build
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm-8 lld-8 libedit-dev gdb && \
+  apt-get install -y build-essential llvm-10 lld-10 libedit-dev gdb && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN ln -sf /usr/bin/ld.lld-8 /usr/bin/ld.lld
+RUN ln -sf /usr/bin/ld.lld-10 /usr/bin/ld.lld
 
 CMD ["/bin/sh"]

--- a/docker/ubuntu32.Dockerfile
+++ b/docker/ubuntu32.Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y tzdata gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make \
-                     libpcre3-dev libevent-dev && \
+                     libpcre3-dev libevent-dev libz-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG crystal_deb

--- a/docker/ubuntu32.Dockerfile
+++ b/docker/ubuntu32.Dockerfile
@@ -1,0 +1,31 @@
+ARG base_docker_image
+FROM ${base_docker_image} as runtime
+
+RUN \
+  apt-get update && \
+  apt-get install -y apt-transport-https && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install -y tzdata gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make \
+                     libpcre3-dev libevent-dev && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG crystal_deb
+COPY ${crystal_deb} /tmp/crystal.deb
+# nightly packages do not have valid version numbers
+RUN dpkg --force-bad-version -i /tmp/crystal.deb
+
+CMD ["/bin/sh"]
+
+FROM runtime as build
+
+RUN \
+  apt-get update && \
+  apt-get install -y build-essential llvm-8 lld-8 libedit-dev gdb && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN ln -sf /usr/bin/ld.lld-8 /usr/bin/ld.lld
+
+ENV LIBRARY_PATH=/usr/lib/crystal/lib/
+
+CMD ["/bin/sh"]

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -43,11 +43,11 @@ RUN sed -i 's|--list -- "$@"|--list "$@"|' /usr/bin/ldd
 # Install dependencies
 RUN apk add --no-cache \
       # Statically-compiled llvm
-      llvm8-dev llvm8-static \
+      llvm10-dev llvm10-static \
       # Static zlib, libyaml, libxml2, pcre, and libevent
       zlib-dev yaml-dev libxml2-dev pcre-dev libevent-static \
       # Build tools
-      git gcc g++ make automake libtool autoconf bash coreutils
+      git gcc g++ make automake libtool autoconf bash coreutils curl
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -94,11 +94,10 @@ ARG musl_target
 RUN git clone https://github.com/crystal-lang/shards \
  && cd shards \
  && git checkout ${shards_version} \
- && make lib \
+ && make SHARDS=false CRYSTAL=/crystal/bin/crystal \
+         FLAGS="--stats --target ${musl_target} --static ${release:+--release}" \
  \
- && /crystal/bin/crystal build --stats --target ${musl_target} \
-    ./src/shards.cr -o shards --static ${release:+--release} \
- && ([ "$(ldd shards | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd shards; exit 1; })
+ && ([ "$(ldd bin/shards | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd bin/shards; exit 1; })
 
 COPY files/crystal-wrapper /output/bin/crystal
 COPY --from=debian /bdwgc/.libs/libgc.a /libgc-debian.a
@@ -120,7 +119,7 @@ RUN \
  && cp /crystal/.build/crystal /output/lib/crystal/bin/crystal \
  \
  # Copy shards to /lib/crystal/bin/
- && cp /shards/shards /output/lib/crystal/bin/shards \
+ && cp /shards/bin/shards /output/lib/crystal/bin/shards \
  && ln -s ../lib/crystal/bin/shards /output/bin/shards \
  \
  # Copy stdlib to /share/crystal/src/

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --no-cache \
       # Statically-compiled llvm
       llvm10-dev llvm10-static \
       # Static zlib, libyaml, libxml2, pcre, and libevent
-      zlib-dev yaml-dev libxml2-dev pcre-dev libevent-static \
+      zlib-static yaml-static libxml2-dev pcre-dev libevent-static \
       # Build tools
       git gcc g++ make automake libtool autoconf bash coreutils curl
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -48,14 +48,14 @@ BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
 BUILD_ARGS64 = $(BUILD_ARGS_COMMON) \
                --build-arg previous_crystal_release=$(PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ)	\
                --build-arg debian_image=debian:10 \
-               --build-arg alpine_image=alpine:3.10 \
+               --build-arg alpine_image=alpine:3.12 \
                --build-arg musl_target=x86_64-linux-musl \
                --build-arg gnu_target=x86_64-unknown-linux-gnu
 
 BUILD_ARGS32 = $(BUILD_ARGS_COMMON) \
                --build-arg previous_crystal_release=$(PREVIOUS_CRYSTAL_RELEASE_LINUX32_TARGZ) \
                --build-arg debian_image=i386/debian:10 \
-               --build-arg alpine_image=i386/alpine:3.10 \
+               --build-arg alpine_image=i386/alpine:3.12 \
                --build-arg musl_target=i686-linux-musl \
                --build-arg gnu_target=i686-unknown-linux-gnu
 


### PR DESCRIPTION
Ubuntu has dropped i386 architecture in 19.10, so there won't be a 20.04 LTS release for i386.

Also adds a separate Dockerfile for i386 to maintain them separately.