### PR TITLE
Use make update path

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -33,6 +33,4 @@ RUN \
   apk add --update --no-cache --force-overwrite \
     llvm-dev llvm-static g++
 
-ENV LIBRARY_PATH=/usr/lib/crystal/lib/
-
 CMD ["/bin/sh"]

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -26,6 +26,4 @@ RUN \
 
 RUN ln -sf /usr/bin/ld.lld-8 /usr/bin/ld.lld
 
-ENV LIBRARY_PATH=/usr/lib/crystal/lib/
-
 CMD ["/bin/sh"]

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -85,7 +85,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  && git checkout ${crystal_sha1} \
  \
  && make crystal stats=true static=true ${release:+release=true} \
-                 CRYSTAL_CONFIG_TARGET=${gnu_target} \
+                 CRYSTAL_CONFIG_TARGET=${gnu_target} CRYSTAL_CONFIG_LIBRARY_PATH= \
  && ([ "$(ldd .build/crystal | wc -l)" -eq "1" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
 
 # Build shards

--- a/linux/files/crystal-wrapper
+++ b/linux/files/crystal-wrapper
@@ -99,7 +99,6 @@ ROOT_DIR="$SCRIPT_DIR/.."
 
 export CRYSTAL_PATH="${CRYSTAL_PATH:-"lib:$ROOT_DIR/share/crystal/src"}"
 export PATH="$ROOT_DIR/lib/crystal/bin:$PATH"
-export LIBRARY_PATH="$ROOT_DIR/lib/crystal/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$ROOT_DIR/lib/crystal/lib"
 
 exec "$ROOT_DIR/lib/crystal/bin/crystal" "${@}"

--- a/linux/files/crystal-wrapper
+++ b/linux/files/crystal-wrapper
@@ -96,8 +96,8 @@ _canonicalize_file_path() {
 
 SCRIPT_DIR="$(dirname "$(realpath "$0" || echo "$0")")"
 ROOT_DIR="$SCRIPT_DIR/.."
-
-export CRYSTAL_PATH="${CRYSTAL_PATH:-"lib:$ROOT_DIR/share/crystal/src"}"
+EMBEDDED_CRYSTAL_PATH=$("$ROOT_DIR/lib/crystal/bin/crystal" env CRYSTAL_PATH)
+export CRYSTAL_PATH="${CRYSTAL_PATH:-"$EMBEDDED_CRYSTAL_PATH:$ROOT_DIR/share/crystal/src"}"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$ROOT_DIR/lib/crystal/lib"
 
 exec "$ROOT_DIR/lib/crystal/bin/crystal" "${@}"

--- a/linux/files/crystal-wrapper
+++ b/linux/files/crystal-wrapper
@@ -98,7 +98,6 @@ SCRIPT_DIR="$(dirname "$(realpath "$0" || echo "$0")")"
 ROOT_DIR="$SCRIPT_DIR/.."
 
 export CRYSTAL_PATH="${CRYSTAL_PATH:-"lib:$ROOT_DIR/share/crystal/src"}"
-export PATH="$ROOT_DIR/lib/crystal/bin:$PATH"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$ROOT_DIR/lib/crystal/lib"
 
 exec "$ROOT_DIR/lib/crystal/bin/crystal" "${@}"

--- a/omnibus/config/software/crystal.rb
+++ b/omnibus/config/software/crystal.rb
@@ -27,7 +27,8 @@ unless FIRST_RUN
   llvm_bin = Omnibus::Software.load(project, "llvm_bin", nil)
 end
 
-output_bin = "#{install_dir}/embedded/bin/crystal"
+output_path = "#{install_dir}/embedded/bin"
+output_bin = "#{output_path}/crystal"
 
 if FIRST_RUN
   env["PATH"] = "#{project_dir}/deps:#{env["PATH"]}"
@@ -49,7 +50,7 @@ build do
   command "mkdir .build", env: env
   command "echo #{Dir.pwd}", env: env
   command "cp #{Dir.pwd}/crystal-#{ohai['os']}-#{ohai['kernel']['machine']} .build/crystal", env: env
-  command "bin/crystal build src/compiler/crystal.cr --release --no-debug -o #{output_bin} -D without_openssl -D without_zlib", env: env
+  command "make crystal stats=true release=true FLAGS=--no-debug CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
 
   block do
     raise "Could not build crystal" unless File.exists?(output_bin)

--- a/omnibus/config/templates/crystal/crystal.erb
+++ b/omnibus/config/templates/crystal/crystal.erb
@@ -96,6 +96,7 @@ _canonicalize_file_path() {
 
 SCRIPT_PATH="$(dirname "$(realpath "$0" || echo $0)")"
 INSTALL_DIR="$(realpath "$SCRIPT_PATH/..")"
-export CRYSTAL_PATH=${CRYSTAL_PATH:-"lib:$INSTALL_DIR/src"}
+EMBEDDED_CRYSTAL_PATH=$("$INSTALL_DIR/embedded/bin/crystal" env CRYSTAL_PATH)
+export CRYSTAL_PATH="${CRYSTAL_PATH:-"$EMBEDDED_CRYSTAL_PATH:$INSTALL_DIR/src"}"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$INSTALL_DIR/embedded/lib"
 "$INSTALL_DIR/embedded/bin/crystal" "$@"

--- a/omnibus/config/templates/crystal/crystal.erb
+++ b/omnibus/config/templates/crystal/crystal.erb
@@ -97,6 +97,5 @@ _canonicalize_file_path() {
 SCRIPT_PATH="$(dirname "$(realpath "$0" || echo $0)")"
 INSTALL_DIR="$(realpath "$SCRIPT_PATH/..")"
 export CRYSTAL_PATH=${CRYSTAL_PATH:-"lib:$INSTALL_DIR/src"}
-export PATH="$INSTALL_DIR/embedded/bin:$PATH"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$INSTALL_DIR/embedded/lib"
 "$INSTALL_DIR/embedded/bin/crystal" "$@"

--- a/omnibus/config/templates/crystal/crystal.erb
+++ b/omnibus/config/templates/crystal/crystal.erb
@@ -98,6 +98,5 @@ SCRIPT_PATH="$(dirname "$(realpath "$0" || echo $0)")"
 INSTALL_DIR="$(realpath "$SCRIPT_PATH/..")"
 export CRYSTAL_PATH=${CRYSTAL_PATH:-"lib:$INSTALL_DIR/src"}
 export PATH="$INSTALL_DIR/embedded/bin:$PATH"
-export LIBRARY_PATH="$INSTALL_DIR/embedded/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
 export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:+$CRYSTAL_LIBRARY_PATH:}$INSTALL_DIR/embedded/lib"
 "$INSTALL_DIR/embedded/bin/crystal" "$@"


### PR DESCRIPTION
Thanks to https://github.com/crystal-lang/crystal/pull/9423 we can tidy up the darwin build and wrapper scripts for linux and darwin.

The destination directory for shards `lib` is extracted from compiler binary.