### PR TITLE
Avoid requiring shards to build shards

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -94,7 +94,7 @@ ARG musl_target
 RUN git clone https://github.com/crystal-lang/shards \
  && cd shards \
  && git checkout ${shards_version} \
- && shards install --production \
+ && make lib \
  \
  && /crystal/bin/crystal build --stats --target ${musl_target} \
     ./src/shards.cr -o shards --static ${release:+--release} \

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -36,7 +36,7 @@ relative_path "shards-#{version}"
 env = with_standard_compiler_flags(with_embedded_path)
 
 build do
-  command "#{Dir.pwd}/shards-#{ohai['os']}-#{ohai['kernel']['machine']} install --production", env: env
+  command "make lib", env: env
 
   command "#{install_dir}/bin/crystal" \
           " build" \


### PR DESCRIPTION
This changes uses `make lib` so it does not require shards to be available.

This is also needed to unlock builds of 1.0.0-dev (since molinillo states `crystal: 0.x`)