### PR TITLE
Use canonical base url for generating docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  && cd crystal \
  && git checkout ${crystal_sha1} \
  \
- && make docs DOCS_OPTIONS='--json-config-url=/api/versions.json'\
+ && make docs DOCS_OPTIONS='--json-config-url=/api/versions.json  --canonical-base-url="https://crystal-lang.org/api/latest/"'\
  && git describe --tags --long --always 2>/dev/null > ./docs/revision.txt \
  && mv ./docs ./${output_docs_base_name} \
  \


### PR DESCRIPTION
Enable crystal-lang/crystal#9917

crystal-lang/crystal#10007 adds the same on CI for nightly docs