### PR TITLE
Restore openssl-dev in alpine images

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -5,7 +5,7 @@ RUN \
     # core dependencies
     gc-dev gcc gmp-dev libatomic_ops libevent-static musl-dev pcre-dev \
     # stdlib dependencies
-    libxml2-dev openssl-libs-static tzdata yaml-static zlib-static \
+    libxml2-dev openssl-dev openssl-libs-static tzdata yaml-static zlib-static \
     # dev tools
     make git
 


### PR DESCRIPTION
Otherwise /usr/lib/pkgconfig/libcrypto.pc is missing and LibCrypto / LibSSL will fail to link

Without openssl-dev package

```
/ # crystal eval 'require "openssl"; pp! LibSSL::OPENSSL_VERSION'
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: _main.o: in function `__crystal_main':
/usr/share/crystal/src/openssl/lib_ssl.cr:255: undefined reference to `SSL_library_init'
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/share/crystal/src/openssl/lib_ssl.cr:255: undefined reference to `SSL_load_error_strings'
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/share/crystal/src/openssl/lib_ssl.cr:255: undefined reference to `OPENSSL_add_all_algorithms_noconf'
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/share/crystal/src/openssl/lib_ssl.cr:255: undefined reference to `ERR_load_crypto_strings'
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `cc "${@}" -o /root/.cache/crystal/crystal-run-eval.tmp  -rdynamic -L/usr/bin/../lib/crystal/lib `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lpcre -lm -lgc -lpthread /usr/share/crystal/src/ext/libcrystal.a -levent -lrt`
```

With openssl-dev these are the output

```
/ # pkg-config --libs --silence-errors libssl
-lssl 
/ # pkg-config --libs --silence-errors libcrypto
-lcrypto 
```

and then we have

```
# crystal eval 'require "openssl"; pp! LibSSL::OPENSSL_VERSION'
LibSSL::OPENSSL_VERSION # => "1.1.1"
```