### PR TITLE
Fix static executable checks

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -86,7 +86,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  \
  && make crystal stats=true static=true ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} CRYSTAL_CONFIG_LIBRARY_PATH= \
- && ([ "$(ldd .build/crystal | wc -l)" -eq "1" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
+ && ([ "$(ldd .build/crystal | wc -l)" -eq "0" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
 
 # Build shards
 ARG shards_version
@@ -97,7 +97,7 @@ RUN git clone https://github.com/crystal-lang/shards \
  && make SHARDS=false CRYSTAL=/crystal/bin/crystal \
          FLAGS="--stats --target ${musl_target} --static ${release:+--release}" \
  \
- && ([ "$(ldd bin/shards | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd bin/shards; exit 1; })
+ && ([ "$(ldd bin/shards | wc -l)" -eq "0" ] || { echo 'shards is not statically linked'; ldd bin/shards; exit 1; })
 
 COPY files/crystal-wrapper /output/bin/crystal
 COPY --from=debian /bdwgc/.libs/libgc.a /libgc-debian.a


### PR DESCRIPTION
Fixes static executable checks which currently fails on alpine 3.13 (see https://github.com/crystal-lang/distribution-scripts/pull/83#issue-589836036).

The reason is explained in https://github.com/crystal-lang/distribution-scripts/pull/87#issuecomment-817865398

Follow-up to #79