### PR TITLE
Fix broken linux dist caused by curl regression

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -11,6 +11,9 @@ ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 ENV CC="clang-8"
 
+# Termporary pinning libcurl oldrelease because current (7.74.0) is broken
+RUN apt-get install -y --allow-downgrades libcurl3-gnutls=7.64.0-4+deb10u2
+
 # Build libgc
 ARG gc_version
 ARG libatomic_ops_version


### PR DESCRIPTION
Dist builds are currently broken because git checkout is broken by a regression in curl with HTTP/2 (https://daniel.haxx.se/blog/2021/04/14/curl-7-76-1-h2-works-again/).
We're using the curl package from buster-backports which ships curl 7.74.0 (including the regression). This fix temporarily pins to 7.64.0.

@bcardiff Is there a particular reason for using packages from buster-backport for the linux build? If we'd use packages from stable, the bug would not be present.