### PR TITLE
Add support for generic deb/rpm distros

### DIFF
--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -106,12 +106,36 @@ _discover_distro_repo() {
       _check_version_id
       DISTRO_REPO="openSUSE_Leap_${VERSION_ID}"
       ;;
-    *)
+    "")
       _error "Unable to identify distribution. You may specify one with environment variable DISTRO_REPO"
       _error "Please, report to https://forum.crystal-lang.org/c/help-support/11"
       exit 1
       ;;
+    *)
+      # If there's no dedicated repository for the distro, try to figure out
+      # if the distro is apt or rpm based and use a default repository.
+      _discover_distro_type
+
+      case "$DISTRO_TYPE" in
+      deb)
+        DISTRO_REPO="Debian_Unstable"
+        ;;
+      rpm)
+        DISTRO_REPO="RHEL_7"
+        ;;
+      *)
+        _error "Unable to identify distribution type ($ID). You may specify a repository with the environment variable DISTRO_REPO"
+        _error "Please, report to https://forum.crystal-lang.org/c/help-support/11"
+        exit 1
+        ;;
+      esac
   esac
+}
+
+_discover_distro_type() {
+  DISTRO_TYPE=""
+  [[ $(command -v apt-get) ]] && DISTRO_TYPE="deb" && return
+  [[ $(command -v yum) ]]     && DISTRO_TYPE="rpm" && return
 }
 
 if [[ $EUID -ne 0 ]]; then

--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -149,6 +149,7 @@ fi
 
 _install_apt() {
   if [[ -z $(command -v wget &> /dev/null) ]] || [[ -z $(command -v gpg &> /dev/null) ]]; then
+    [[ -f /etc/apt/sources.list.d/crystal.list ]] && rm -f /etc/apt/sources.list.d/crystal.list
     apt-get update
     apt-get install -y wget gpg
   fi

--- a/packages/test/elementary_os.bats
+++ b/packages/test/elementary_os.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "Elementary OS stable" {
+  ./test-install-on-docker.sh elementary/docker:stable
+}
+
+@test "Elementary OS unstable" {
+  ./test-install-on-docker.sh elementary/docker:unstable
+}

--- a/packages/test/mint.bats
+++ b/packages/test/mint.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "Linux Mint 20" {
+  ./test-install-on-docker.sh linuxmintd/mint20-amd64
+}
+
+@test "Linux Mint 19" {
+  ./test-install-on-docker.sh linuxmintd/mint19-amd64
+}


### PR DESCRIPTION
This is a follow-up on #91 improving support for distributions for which OBS does not have a dedicated repository but are based on deb or rpm. The installer then defaults to `Debian_Testing`  and `RHEL_7` repositories.