### PR TITLE
Add support for nightly and unstable builds

### DIFF
--- a/packages/obs-push.sh
+++ b/packages/obs-push.sh
@@ -32,18 +32,10 @@ cp "$CRYSTAL_LINUX64_TARGZ" "$PACKAGE-snapshot-linux-x86_64.tar.gz"
 cp "$CRYSTAL_LINUX32_TARGZ" "$PACKAGE-snapshot-linux-i686.tar.gz"
 cp "$CRYSTAL_DOCS_TARGZ" "$PACKAGE-snapshot-docs.tar.gz"
 
-osc add "$PACKAGE-snapshot-linux-x86_64.tar.gz"
-osc add "$PACKAGE-snapshot-linux-i686.tar.gz"
-osc add "$PACKAGE-snapshot-docs.tar.gz"
-
 # Write version info
 echo "$VERSION" > "$PACKAGE-version.txt"
 echo "$SNAPSHOT" > "$PACKAGE-snapshot.txt"
 echo "${COMMIT_HASH:0:8}" > "$PACKAGE-commit_hash.txt"
-
-osc add "$PACKAGE-version.txt"
-osc add "$PACKAGE-snapshot.txt"
-osc add "$PACKAGE-commit_hash.txt"
 
 # Commit changes to OBS
 message="Update to $SNAPSHOT - $COMMIT_HASH"

--- a/packages/obs-push.sh
+++ b/packages/obs-push.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# $ ./trigger-obs-build.sh PROJECT VERSION SNAPSHOT COMMIT_HASH CRYSTAL_LINUX64_TARGZ CRYSTAL_LINUX32_TARGZ CRYSTAL_DOCS_TARGZ
+
+# This script checks out PROJECT, updates the version information
+# (VERSION, SNAPSHOT, COMMIT_HASH) and build artifacts (*_TARGZ arguments),
+# and commits the changes to OBS.
+#
+# Requirements:
+# * packages: osc, python3-m2crypto
+# * configured ~/.oscrc with credentials
+
+set -eu
+
+PACKAGE="crystal"
+
+PROJECT=$1
+VERSION=$2
+SNAPSHOT=$3
+COMMIT_HASH=$4
+CRYSTAL_LINUX64_TARGZ=$5
+CRYSTAL_LINUX32_TARGZ=$6
+CRYSTAL_DOCS_TARGZ=$7
+
+# Checkout OBS package
+osc checkout "$PROJECT" "$PACKAGE"
+
+pushd "$PROJECT/$PACKAGE"
+
+# Copy build artifacts
+cp "$CRYSTAL_LINUX64_TARGZ" "$PACKAGE-snapshot-linux-x86_64.tar.gz"
+cp "$CRYSTAL_LINUX32_TARGZ" "$PACKAGE-snapshot-linux-i686.tar.gz"
+cp "$CRYSTAL_DOCS_TARGZ" "$PACKAGE-snapshot-docs.tar.gz"
+
+osc add "$PACKAGE-snapshot-linux-x86_64.tar.gz"
+osc add "$PACKAGE-snapshot-linux-i686.tar.gz"
+osc add "$PACKAGE-snapshot-docs.tar.gz"
+
+# Write version info
+echo "$VERSION" > "$PACKAGE-version.txt"
+echo "$SNAPSHOT" > "$PACKAGE-snapshot.txt"
+echo "${COMMIT_HASH:0:8}" > "$PACKAGE-commit_hash.txt"
+
+osc add "$PACKAGE-version.txt"
+osc add "$PACKAGE-snapshot.txt"
+osc add "$PACKAGE-commit_hash.txt"
+
+# Commit changes to OBS
+message="Update to $SNAPSHOT - $COMMIT_HASH"
+osc vc -m "$message"
+osc diff
+osc commit -m "$message"
+
+# Remove OSC working dir
+popd
+rm -r "$PROJECT/$PACKAGE"

--- a/packages/obs-push.sh
+++ b/packages/obs-push.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# $ ./trigger-obs-build.sh PROJECT VERSION SNAPSHOT COMMIT_HASH CRYSTAL_LINUX64_TARGZ CRYSTAL_LINUX32_TARGZ CRYSTAL_DOCS_TARGZ
+# $ ./obs-push.sh PROJECT VERSION SNAPSHOT COMMIT_HASH CRYSTAL_LINUX64_TARGZ CRYSTAL_LINUX32_TARGZ CRYSTAL_DOCS_TARGZ
 
-# This script checks out PROJECT, updates the version information
+# This script uses osc to check out PROJECT, update the version information
 # (VERSION, SNAPSHOT, COMMIT_HASH) and build artifacts (*_TARGZ arguments),
-# and commits the changes to OBS.
+# and commit the changes to OBS.
 #
 # Requirements:
-# * packages: osc, python3-m2crypto
+# * packages: osc build which
 # * configured ~/.oscrc with credentials
 
 set -eu

--- a/packages/obs-push.sh
+++ b/packages/obs-push.sh
@@ -32,13 +32,13 @@ cp "$CRYSTAL_LINUX64_TARGZ" "$PACKAGE-snapshot-linux-x86_64.tar.gz"
 cp "$CRYSTAL_LINUX32_TARGZ" "$PACKAGE-snapshot-linux-i686.tar.gz"
 cp "$CRYSTAL_DOCS_TARGZ" "$PACKAGE-snapshot-docs.tar.gz"
 
-# Write version info
-echo "$VERSION" > "$PACKAGE-version.txt"
-echo "$SNAPSHOT" > "$PACKAGE-snapshot.txt"
-echo "${COMMIT_HASH:0:8}" > "$PACKAGE-commit_hash.txt"
+# Update version in *.dsc and *.spec
+PACKAGE_VERSION="${VERSION}~${SNAPSHOT}.git.${COMMIT_HASH:0:8}"
+sed -i -e "s/^Version: .*/Version: ${PACKAGE_VERSION}-1/" *.dsc
+sed -i -e "s/^Version: .*/Version: ${PACKAGE_VERSION}/" *.spec
 
 # Commit changes to OBS
-message="Update to $SNAPSHOT - $COMMIT_HASH"
+message="Update $PROJECT to $SNAPSHOT"
 osc vc -m "$message"
 osc diff
 osc commit -m "$message"

--- a/packages/obs-setup.sh
+++ b/packages/obs-setup.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
-# This script installs OSC on debian/ubuntu and configures credentials for
+# This script installs configures OSC credentials for
 # https://api.opensuse.org
 #
 # Environment variables:
 # * OBS_USER: username
 # * OBS_PASSWORD: password
-
-# Install OSC
-apt update
-apt install -y osc python3-m2crypto
 
 # Configure OSC
 cat > ~/.oscrc <<EOF

--- a/packages/obs-setup.sh
+++ b/packages/obs-setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This script installs OSC on debian/ubuntu and configures credentials for
+# https://api.opensuse.org
+#
+# Environment variables:
+# * OBS_USER: username
+# * OBS_PASSWORD: password
+
+# Install OSC
+apt update
+apt install -y osc python3-m2crypto
+
+# Configure OSC
+cat > ~/.oscrc <<EOF
+[general]
+apiurl = https://api.opensuse.org
+
+[https://api.opensuse.org]
+user=$OBS_USER
+pass=$OBS_PASSWORD
+EOF

--- a/packages/obs-setup.sh
+++ b/packages/obs-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script installs configures OSC credentials for
+# This script configures OSC credentials for
 # https://api.opensuse.org
 #
 # Environment variables:

--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -167,6 +167,18 @@ case $i in
 esac
 done
 
+case $CHANNEL in
+  stable)
+    ;;
+  nightly | unstable)
+    OBS_PROJECT="${OBS_PROJECT}:${CHANNEL}"
+    ;;
+  *)
+    _error "Unsupported channel $CHANNEL"
+    exit 1
+    ;;
+esac
+
 if [[ -z "${DISTRO_REPO}" ]]; then
   _discover_distro_repo
 fi

--- a/packages/support/test-install.sh
+++ b/packages/support/test-install.sh
@@ -48,21 +48,3 @@ shards --version
 crystal --version
 shards --version
 crystal eval 'puts "Hello World!"'
-
-# Additional packages needed on docker images to run scripts/install.sh
-#
-# | Docker Image           | gnupg | ca-certificates | apt-transport-https |
-# |------------------------|-------|-----------------|---------------------|
-# | ubuntu:focal           | x     |                 |                     |
-# | ubuntu:eoan            | x     |                 |                     |
-# | ubuntu:bionic          | x     |                 |                     |
-# | ubuntu:xenial          | x     |                 | x                   |
-# | ubuntu:trusty          | x     |                 | x                   |
-# | i386/ubuntu:xenial     | x     |                 | x                   |
-# |------------------------|-------|-----------------|---------------------|
-# | debian:10 (buster)     | x     | x               |                     |
-# | debian:9 (stretch)     | x     | x               | x                   |
-# | debian:8 (jessie)      | x     | x               | x                   |
-# | i386/debian:8 (jessie) | x     | x               | x                   |
-# |------------------------|-------|-----------------|---------------------|
-#

--- a/packages/support/test-install.sh
+++ b/packages/support/test-install.sh
@@ -14,6 +14,16 @@ crystal --version
 shards --version
 crystal eval 'puts "Hello World!"'
 
+../scripts/install.sh --channel=unstable
+crystal --version
+shards --version
+crystal eval 'puts "Hello World!"'
+
+../scripts/install.sh --channel=nightly
+crystal --version
+shards --version
+crystal eval 'puts "Hello World!"'
+
 # OBS doesn't have any fully valid older releases yet, so skipping the following
 # checks for now.
 exit 0
@@ -35,16 +45,6 @@ shards --version
 [[ $DISTRO_TYPE == "deb" ]] && crystal eval 'puts "Hello World!"'
 
 ../scripts/install.sh --crystal=0.35
-crystal --version
-shards --version
-crystal eval 'puts "Hello World!"'
-
-../scripts/install.sh --channel=unstable
-crystal --version
-shards --version
-crystal eval 'puts "Hello World!"'
-
-../scripts/install.sh --channel=nightly
 crystal --version
 shards --version
 crystal eval 'puts "Hello World!"'


### PR DESCRIPTION
Nightlies and unstable builds are published in subprojects on OBS:
* [devel:languages:crystal:nightly](https://build.opensuse.org/package/show/devel:languages:crystal:nightly)
* [devel:languages:crystal:unstable](https://build.opensuse.org/package/show/devel:languages:crystal:unstable)

The script `obs-push.sh` is responsible for pushing the updated build information to OBS.

The installer simply appends `:${CHANNEL}` to the project name.