### PR TITLE
Omnibus: build libyaml with --disable-shared

### DIFF
--- a/omnibus/config/software/libyaml.rb
+++ b/omnibus/config/software/libyaml.rb
@@ -25,7 +25,7 @@ relative_path "yaml-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure --disable-shared --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -45,7 +45,10 @@ end
 source url: "https://github.com/crystal-lang/shards/archive/v#{version}.tar.gz"
 
 relative_path "shards-#{version}"
-env = with_standard_compiler_flags(with_embedded_path)
+env = with_standard_compiler_flags(with_embedded_path(
+  "LIBRARY_PATH" => "#{install_dir}/embedded/lib",
+  "CRYSTAL_LIBRARY_PATH" => "#{install_dir}/embedded/lib"
+))
 
 build do
   make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='--no-debug --release'", env: env

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -52,5 +52,5 @@ env = with_standard_compiler_flags(with_embedded_path(
 
 build do
   make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='--no-debug --release'", env: env
-  command "cp bin/shards #{install_dir}/embedded/bin/shards"
+  copy "bin/shards", "#{install_dir}/embedded/bin/shards"
 end


### PR DESCRIPTION
Removing the dynamic library forces the compiler to pick the static library, removing libyaml as a runtime dependency for shards.

Resolves https://github.com/crystal-lang/crystal/issues/5994

CI run at https://app.circleci.com/pipelines/github/crystal-lang/crystal/5733/workflows/94b82b64-c487-4364-b9f7-424fa591e8ab