### PR TITLE
Remove test for Ubuntu 16.04 (reached EOL)

### DIFF
--- a/packages/test/ubuntu.bats
+++ b/packages/test/ubuntu.bats
@@ -15,7 +15,3 @@
 @test "Ubuntu 18.04" {
   ./test-install-on-docker.sh ubuntu:18.04
 }
-
-@test "Ubuntu 16.04" {
-  ./test-install-on-docker.sh ubuntu:16.04
-}

--- a/packages/test/ubuntu.i386.bats
+++ b/packages/test/ubuntu.i386.bats
@@ -3,7 +3,3 @@
 @test "Ubuntu 18.04 (i386)" {
   ./test-install-on-docker.sh i386/ubuntu:18.04
 }
-
-@test "Ubuntu 16.04 (i386)" {
-  ./test-install-on-docker.sh i386/ubuntu:16.04
-}


### PR DESCRIPTION
Ubuntu 16.04 has reached end of life, so we don't need to run the package tests. They're broken because gpg can't be installed. This should be fixable but is not worth the effort.

We're still providing packages for Ubuntu 16.04 on OBS and they are expected to work.