### PR TITLE
Refactor test-install to only check for single project

### DIFF
--- a/packages/support/test-install.sh
+++ b/packages/support/test-install.sh
@@ -9,42 +9,7 @@ DISTRO_TYPE=""
 # Required for Ubuntu <= 20.04 to not ask for input during package installation
 export DEBIAN_FRONTEND=noninteractive
 
-../scripts/install.sh
-crystal --version
-shards --version
-crystal eval 'puts "Hello World!"'
-
-../scripts/install.sh --channel=unstable
-crystal --version
-shards --version
-crystal eval 'puts "Hello World!"'
-
-../scripts/install.sh --channel=nightly
-crystal --version
-shards --version
-crystal eval 'puts "Hello World!"'
-
-# OBS doesn't have any fully valid older releases yet, so skipping the following
-# checks for now.
-exit 0
-
-# Uninstall explicitly for downgrade
-case $DISTRO_TYPE in
-  deb)
-    apt -y remove crystal
-    ;;
-  *)
-    rpm -e crystal
-    ;;
-esac
-
-../scripts/install.sh --crystal=0.34
-crystal --version
-shards --version
-# Crystal < 0.35 raises execvp (which "pkg-config"): No such file or directory: No such file or directory (Errno)
-[[ $DISTRO_TYPE == "deb" ]] && crystal eval 'puts "Hello World!"'
-
-../scripts/install.sh --crystal=0.35
+../scripts/install.sh ${@}
 crystal --version
 shards --version
 crystal eval 'puts "Hello World!"'


### PR DESCRIPTION
The test-install helper script did a full check on base project plus nightly and unstable channels (the latter is unused currently).

This only works for the main project (`devel:languages:crystal`) but not when testing branches (like `home:straight-shoota:branches:devel:languages:crystal`) because the respective projects for nightly and unstable channels are missing.

This patch simplifies the test-install script to only run on a single channel. But CLI arguments are forwarded to the installer. Instead of a single run of `./support/test-install.sh`, you now have to run it several times with different arguments tp get the same result:
```bash
./support/test-install.sh 
./support/test-install.sh --channel=nightly
./support/test-install.sh --channel=unstable # if used
```

Usually you only need to test a specific channel/project anyways, though.