### PR TITLE
Update installer to install versioned packages

### DIFF
--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -7,8 +7,8 @@ USAGE
 
     $ ./install.sh [--crystal=<crystal-version>] [--channel=stable|unstable|nightly]
 
-  - crystal-version: latest, 1.0.0, 1.1 etc. (Default: latest)
-  - channel: stable, unstable, nightly. (Default: stable)
+  - crystal-version: "latest", or a minor release version like 1.0 or 1.1 (Default: latest)
+  - channel: "stable", "unstable", "nightly" (Default: stable)
 
 REQUIREMENTS
 
@@ -40,7 +40,7 @@ set -eu
 
 OBS_PROJECT=${OBS_PROJECT:-"devel:languages:crystal"}
 DISTRO_REPO=${DISTRO_REPO:-}
-CRYSTAL_VERSION="latest"
+CRYSTAL_VERSION=${CRYSTAL_VERSION:-"latest"}
 CHANNEL="stable"
 
 _error() {
@@ -198,8 +198,7 @@ _install_apt() {
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     apt-get install -y crystal
   else
-    # Appending * allows --crystal=x.y and resolution of package-iteration https://askubuntu.com/a/824926/1101493
-    apt-get install -y crystal="$CRYSTAL_VERSION*"
+    apt-get install -y "crystal${CRYSTAL_VERSION}"
   fi
 }
 
@@ -223,14 +222,7 @@ EOF
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     yum install -y crystal
   else
-    command -v repoquery >/dev/null || yum install -y yum-utils
-    CRYSTAL_PACKAGE=$(repoquery crystal-$CRYSTAL_VERSION* | tail -n1)
-    if [ -z "$CRYSTAL_PACKAGE" ]
-    then
-      _error "Unable to find a package for crystal $CRYSTAL_VERSION"
-    else
-      yum install -y $CRYSTAL_PACKAGE
-    fi
+    yum install -y "crystal${CRYSTAL_VERSION}"
   fi
 }
 
@@ -242,14 +234,7 @@ _install_dnf() {
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     dnf install -y crystal
   else
-    command -v repoquery >/dev/null || dnf install -y dnf-utils
-    CRYSTAL_PACKAGE=$(repoquery crystal-$CRYSTAL_VERSION* | tail -n1)
-    if [ -z "$CRYSTAL_PACKAGE" ]
-    then
-      _error "Unable to find a package for crystal $CRYSTAL_VERSION"
-    else
-      dnf install -y $CRYSTAL_PACKAGE
-    fi
+    dnf install -y "crystal${CRYSTAL_VERSION}"
   fi
 }
 
@@ -266,7 +251,7 @@ _install_zypper() {
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     zypper --non-interactive install crystal
   else
-    zypper --non-interactive install crystal="$CRYSTAL_VERSION*"
+    zypper --non-interactive install "crystal${CRYSTAL_VERSION}"
   fi
 }
 

--- a/packages/test-install-on-docker.sh
+++ b/packages/test-install-on-docker.sh
@@ -4,4 +4,4 @@ set -eu
 
 docker_image="${1}"
 
-docker run -e OBS_PROJECT="${OBS_PROJECT:-}" --rm -it -v $(pwd)/scripts:/scripts -v $(pwd)/support:/support $docker_image /support/test-install.sh
+docker run -e OBS_PROJECT="${OBS_PROJECT:-}" -e CRYSTAL_VERSION="${CRYSTAL_VERSION:-}" --rm -it -v $(pwd)/scripts:/scripts -v $(pwd)/support:/support $docker_image /bin/sh -c "/support/test-install.sh ${@:2}"


### PR DESCRIPTION
We have versioned packages now on OBS (https://build.opensuse.org/project/show/devel:languages:crystal) for each minor release. This patch adapts the installer script to install these versioned packages when the `--crystal` argument is passed.