### PR TITLE
Remove deb and rpm build instructions

### DIFF
--- a/linux/Dockerfile-fpm
+++ b/linux/Dockerfile-fpm
@@ -1,9 +1,0 @@
-FROM ruby:2.5
-
-RUN apt-get update \
- && apt-get install -y rpm \
- # cleanup
- && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ENV PATH="/usr/local/bundle/bin/:${PATH}"
-RUN gem install --no-document fpm -v 1.10.2

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -28,12 +28,6 @@ OUTPUT_BASENAME64 = $(OUTPUT_DIR)/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION
 OUTPUT_BASENAME32 = $(OUTPUT_DIR)/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)-linux-i686
 FILES = files/crystal-wrapper
 
-DEB_NAME64 = crystal_$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)_amd64.deb
-RPM_NAME64 = crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).x86_64.rpm
-
-DEB_NAME32 = crystal_$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)_i386.deb
-RPM_NAME32 = crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).i386.rpm
-
 DOCKER_BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )
 
 BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
@@ -59,22 +53,14 @@ BUILD_ARGS32 = $(BUILD_ARGS_COMMON) \
                --build-arg musl_target=i686-linux-musl \
                --build-arg gnu_target=i686-unknown-linux-gnu
 
-PACKAGE_BRANDING_ARGS = --maintainer \"$(PACKAGE_MAINTAINER)\" --url \"https://crystal-lang.org/\"
-
-FPM_FLAGS = --name crystal \
-            --version $(CRYSTAL_VERSION) \
-            --iteration $(PACKAGE_ITERATION) \
-            --vendor \"$(PACKAGE_MAINTAINER)\" \
-            --license APACHE-2.0
-
 .PHONY: all
-all: all64 all32 ## Build compressed and distribution packages [default]
+all: all64 all32 ## Build all distribution tarballs [default]
 
 .PHONY: all64
-all64: compress64 package64 ## Build compressed and distribution packages for 64 bits
+all64: compress64 ## Build distribution tarballs for 64 bits
 
 .PHONY: all32
-all32: compress32 package32 ## Build compressed and distribution packages for 32 bits
+all32: compress32 ## Build distribution tarballs for 32 bits
 
 .PHONY: help
 help: ## Show this help
@@ -112,41 +98,6 @@ $(OUTPUT_BASENAME64).tar.gz: $(OUTPUT_BASENAME64).tar
 $(OUTPUT_BASENAME64).tar.xz: $(OUTPUT_BASENAME64).tar
 	xz -T 0 -c $(OUTPUT_BASENAME64).tar > $(OUTPUT_BASENAME64).tar.xz
 
-.PHONY: package64
-package64: $(OUTPUT_DIR)/$(DEB_NAME64) $(OUTPUT_DIR)/$(RPM_NAME64) ## Build distribution packages from the tarballs
-
-.PHONY: docker-fpm
-docker-fpm: Dockerfile-fpm
-	docker build $(DOCKER_BUILD_ARGS) -t crystal-fpm -f Dockerfile-fpm .
-
-$(OUTPUT_DIR)/$(DEB_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
-	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
-    && mv /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/licenses/crystal/LICENSE /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/doc/crystal/copyright \
-    && rm -Rf /tmp/crystal/crystal-*/share/licenses \
-    && fpm --input-type dir --output-type deb \
-           --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
-           --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
-           --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
-           --force --package $(OUTPUT_DIR)/$(DEB_NAME64) \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
-
-$(OUTPUT_DIR)/$(RPM_NAME64): docker-fpm $(OUTPUT_BASENAME64).tar
-	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME64).tar \
-    && fpm --input-type dir --output-type rpm \
-           --architecture x86_64 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-           --force --package $(OUTPUT_DIR)/$(RPM_NAME64) \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
-
 .PHONY: build32
 build32: $(OUTPUT_BASENAME32).tar ## Build the raw uncompressed tarball
 
@@ -165,37 +116,6 @@ $(OUTPUT_BASENAME32).tar.gz: $(OUTPUT_BASENAME32).tar
 
 $(OUTPUT_BASENAME32).tar.xz: $(OUTPUT_BASENAME32).tar
 	xz -T 0 -c $(OUTPUT_BASENAME32).tar > $(OUTPUT_BASENAME32).tar.xz
-
-.PHONY: package32
-package32: $(OUTPUT_DIR)/$(DEB_NAME32) $(OUTPUT_DIR)/$(RPM_NAME32) ## Build distribution packages from the tarballs
-
-$(OUTPUT_DIR)/$(DEB_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
-	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME32).tar \
-    && mv /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/licenses/crystal/LICENSE /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)/share/doc/crystal/copyright \
-    && rm -Rf /tmp/crystal/crystal-*/share/licenses \
-    && fpm --input-type dir --output-type deb \
-           --architecture i386 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkg-config --depends libpcre3-dev --depends libevent-dev \
-           --deb-recommends git --deb-recommends libssl-dev --deb-recommends libz-dev \
-           --deb-suggests libxml2-dev --deb-suggests libgmp-dev --deb-suggests libyaml-dev --deb-suggests libreadline-dev \
-           --force --package $(OUTPUT_DIR)/$(DEB_NAME32) \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
-
-$(OUTPUT_DIR)/$(RPM_NAME32): docker-fpm $(OUTPUT_BASENAME32).tar
-	docker run --rm -v $(CURDIR)/build:/build crystal-fpm /bin/sh -c "\
-    mkdir -p /tmp/crystal \
-    && tar -C /tmp/crystal -xf $(OUTPUT_BASENAME32).tar \
-    && fpm --input-type dir --output-type rpm \
-           --architecture i386 $(PACKAGE_BRANDING_ARGS) \
-           --depends gcc --depends pkgconfig --depends pcre-devel --depends libevent-devel \
-           --force --package $(OUTPUT_DIR)/$(RPM_NAME32) \
-           --prefix /usr \
-           --chdir /tmp/crystal/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION) \
-           $(FPM_FLAGS) bin lib share"
 
 .PHONY: clean
 clean: ## Clean up build directory

--- a/linux/README.md
+++ b/linux/README.md
@@ -2,14 +2,12 @@
 
 The `x86_64` crystal build is built inside an alpine linux container as a
 statically linked binary using musl libc. `libgc` is built on debian
-to make it work on glibc. `deb`s and `rpm`s are created using the `fpm` tool.
+to make it work on glibc.
 The whole process is automated using a `Makefile`.
 
 # Dependencies
 
 - `docker`
-- [`fpm`](https://github.com/jordansissel/fpm)
-- `rpmbuild` (available from the `rpm-org` AUR package)
 
 # Getting started
 


### PR DESCRIPTION
The instructions for building deb and rpm packages are no longer in use and can be removed.

We're building packages on OBS now (https://github.com/crystal-lang/crystal/issues/10626).