### PR TITLE
Fix trailing whitespace with PREVIOUS_CRYSTAL_PACKAGE_ITERATION

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -17,7 +17,7 @@ PACKAGE_ITERATION ?= 1
 PACKAGE_MAINTAINER = Crystal Team <crystal@manas.tech>
 
 PREVIOUS_CRYSTAL_VERSION ?= ## Version of the bootstrap compiler
-PREVIOUS_CRYSTAL_PACKAGE_ITERATION ?= 1 ## Package iteration of the bootstrap compiler
+PREVIOUS_CRYSTAL_PACKAGE_ITERATION ?= 1## Package iteration of the bootstrap compiler
 PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ ?= https://github.com/crystal-lang/crystal/releases/download/$(PREVIOUS_CRYSTAL_VERSION)/crystal-$(PREVIOUS_CRYSTAL_VERSION)-$(PREVIOUS_CRYSTAL_PACKAGE_ITERATION)-linux-x86_64.tar.gz ## url to crystal-{version}-{package}-linux-x86_64.tar.gz
 PREVIOUS_CRYSTAL_RELEASE_LINUX32_TARGZ ?= https://github.com/crystal-lang/crystal/releases/download/$(PREVIOUS_CRYSTAL_VERSION)/crystal-$(PREVIOUS_CRYSTAL_VERSION)-$(PREVIOUS_CRYSTAL_PACKAGE_ITERATION)-linux-i686.tar.gz ## url to crystal-{version}-{package}-linux-i686.tar.gz
 


### PR DESCRIPTION
Fixup for #130

Apparently, adding a comment in that line appends the trailing whitespace to the value.