### PR TITLE
Use magic variables in Makefiles

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -92,7 +92,7 @@ $(OUTPUT_BASENAME64).tar: Dockerfile $(FILES)
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS64) -t crystal-build-temp .
 	container_id="$$(docker create crystal-build-temp)" \
-	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $(OUTPUT_BASENAME64).tar \
+	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
 	  && docker rm -v "$$container_id"
 
 $(OUTPUT_BASENAME64)-bundled.tar: $(OUTPUT_BASENAME64).tar $(OUTPUT_DIR)/bundled-libs.tar
@@ -116,7 +116,7 @@ $(OUTPUT_BASENAME32).tar: Dockerfile $(FILES)
 	mkdir -p $(OUTPUT_DIR)
 	docker build $(BUILD_ARGS32) -t crystal-build32-temp .
 	container_id="$$(docker create crystal-build32-temp)" \
-	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $(OUTPUT_BASENAME32).tar \
+	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
 	  && docker rm -v "$$container_id"
 
 .PHONY: compress32

--- a/snapcraft/Makefile
+++ b/snapcraft/Makefile
@@ -8,7 +8,7 @@ all: snap/snapcraft.yaml
 
 .PHONY: snap/snapcraft.yaml
 snap/snapcraft.yaml:
-	sed 's/$${CRYSTAL_RELEASE_LINUX64_TARGZ}/$(subst /,\/,$(CRYSTAL_RELEASE_LINUX64_TARGZ))/; s/$${SNAP_GRADE}/$(SNAP_GRADE)/' snap/local/snapcraft.yaml.tpl > snap/snapcraft.yaml
+	sed 's/$${CRYSTAL_RELEASE_LINUX64_TARGZ}/$(subst /,\/,$(CRYSTAL_RELEASE_LINUX64_TARGZ))/; s/$${SNAP_GRADE}/$(SNAP_GRADE)/' snap/local/snapcraft.yaml.tpl > $@
 
 clean:
 	rm snap/snapcraft.yaml


### PR DESCRIPTION
This patch extracts the first commit from #51. It applies the use of `$@` in Makefiles.