### PR TITLE
Add pkg-config to bundled dockerfile

### DIFF
--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -2,7 +2,7 @@ ARG debian_image
 FROM ${debian_image} AS debian
 
 RUN apt-get update \
- && apt-get install -y curl build-essential git automake libtool
+ && apt-get install -y curl build-essential git automake libtool pkg-config
 
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 


### PR DESCRIPTION
Building libevent complained about missing `pkg-config`. Not sure why because I'm pretty sure it worked before. But adding it fixes that, so this seems to be the way to go.