### PR TITLE
Fix ARG in multistage `bundled.Dockerfile`

### DIFF
--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -6,11 +6,9 @@ RUN apt-get update \
 
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 
-ARG libpcre_version
-
 # build libpcre
-
 FROM debian AS libpcre
+ARG libpcre_version
 RUN curl https://ftp.pcre.org/pub/pcre/pcre-${libpcre_version}.tar.gz | tar -zx \
  && cd pcre-${libpcre_version} \
  && ./configure --disable-shared --disable-cpp --enable-jit --enable-utf --enable-unicode-properties \
@@ -30,6 +28,8 @@ RUN git clone https://github.com/libevent/libevent \
 FROM debian
 ARG crystal_version
 ARG package_iteration
+ARG libpcre_version
+ARG libevent_version
 
 RUN mkdir -p /output/lib/crystal/lib/
 


### PR DESCRIPTION
`ARG` instructions in a Dockerfile need to be repeated for every stage in a multistage build.
I have no idea why this worked when I first tested it, but now it doesn't anymore (https://github.com/crystal-lang/distribution-scripts/pull/143#issuecomment-933596413). Apparently, it should've never worked. https://github.com/crystal-lang/distribution-scripts/pull/102#discussion_r722506331

Successful CI run: https://app.circleci.com/pipelines/github/crystal-lang/crystal/6956/workflows/b013a39d-3bcc-4c07-b3c6-b3cc581649ed/jobs/64412