### PR TITLE
Fix docs/Makefile use build docker image

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 CRYSTAL_VERSION ?=                 ## How the binaries should be branded
 CRYSTAL_SHA1 ?= $(CRYSTAL_VERSION) ## Git tag/branch/sha1 to checkout and build source
-CRYSTAL_DOCKER_IMAGE ?= crystallang/crystal:$(CRYSTAL_VERSION) ## Which crystal docker build image to use
+CRYSTAL_DOCKER_IMAGE ?= crystallang/crystal:$(CRYSTAL_VERSION)-build ## Which crystal docker build image to use
 
 OUTPUT_DIR = build
 OUTPUT_DOCS_BASE_NAME = crystal-$(CRYSTAL_VERSION)-docs


### PR DESCRIPTION
The non-build image misses LLVM which is required for building stdlib docs