### PR TITLE
Fix merging bundled tarball 

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -85,9 +85,14 @@ $(OUTPUT_BASENAME64).tar: Dockerfile $(FILES)
 	  && docker cp "$$container_id":/output/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION).tar $@ \
 	  && docker rm -v "$$container_id"
 
-$(OUTPUT_BASENAME64)-bundled.tar: $(OUTPUT_BASENAME64).tar $(OUTPUT_DIR)/bundled-libs.tar
-	cp $< $@
-	tar -Af $@ $(OUTPUT_DIR)/bundled-libs.tar
+$(OUTPUT_BASENAME64)-bundled.tar: $(OUTPUT_BASENAME64)-bundled
+	tar -C $(OUTPUT_BASENAME64)-bundled -cf $@ ./
+
+$(OUTPUT_BASENAME64)-bundled: $(OUTPUT_BASENAME64).tar $(OUTPUT_DIR)/bundled-libs.tar
+	rm -rf $@
+	mkdir -p $@
+	tar -C $@ -xf $(OUTPUT_BASENAME64).tar
+	tar -C $@ -xf $(OUTPUT_DIR)/bundled-libs.tar
 
 $(OUTPUT_DIR)/bundled-libs.tar: bundled.dockerfile
 	mkdir -p $(OUTPUT_DIR)


### PR DESCRIPTION
For some reason appending the contents of the lib tarball via `tar -A` fails on CI. It works locally for me, but the CI artifact is broken.
So instead we build the bundled tarball by extracting the base and lib tarballs and packing them up in a new archive.

The first commit pins the libevent version, which was previously missing.

Broken artifact:
https://64721-6887813-gh.circle-artifacts.com/0/dist_packages/crystal-1.2.0-dev-1-linux-x86_64-bundled.tar.gz

```
...
crystal-1.2.0-dev-1/lib/crystal/bin/shards
crystal-1.2.0-dev-1/lib/crystal/bin/crystal
tar: Skipping to next header
crystal-1.2.0-dev-1/
crystal-1.2.0-dev-1/lib/
tar: Skipping to next header
crystal-1.2.0-dev-1/lib/crystal/
crystal-1.2.0-dev-1/lib/crystal/lib/
crystal-1.2.0-dev-1/lib/crystal/lib/libpcre.a
crystal-1.2.0-dev-1/lib/crystal/lib/libevent_pthreads.a
crystal-1.2.0-dev-1/lib/crystal/lib/libevent.a
tar: Exiting with failure status due to previous errors
```

CI workflow run: https://app.circleci.com/pipelines/github/crystal-lang/crystal?branch=ci%2Fbundled-tarball