### PR TITLE
Installer: Change dependencies validation

### DIFF
--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -189,7 +189,7 @@ if [[ -z "${DISTRO_REPO}" ]]; then
 fi
 
 _install_apt() {
-  if [[ -z $(command -v wget &> /dev/null) ]] || [[ -z $(command -v gpg &> /dev/null) ]]; then
+  if ! command -v wget &> /dev/null || ! command -v gpg &> /dev/null; then
     [[ -f /etc/apt/sources.list.d/crystal.list ]] && rm -f /etc/apt/sources.list.d/crystal.list
     apt-get update
     apt-get install -y wget gpg
@@ -244,7 +244,7 @@ _install_dnf() {
 }
 
 _install_zypper() {
-  if [[ -z $(command -v curl &> /dev/null) ]]; then
+  if ! command -v curl &> /dev/null; then
     zypper refresh
     zypper install -y curl
   fi


### PR DESCRIPTION
The way this conditional has been implemented seems to be not working on Ubuntu Xenial Releases:

```bash
$ cat /etc/os-release 
NAME="Ubuntu"
VERSION="16.04.7 LTS (Xenial Xerus)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 16.04.7 LTS"
VERSION_ID="16.04"
HOME_URL="http://www.ubuntu.com/"
SUPPORT_URL="http://help.ubuntu.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
VERSION_CODENAME=xenial
UBUNTU_CODENAME=xenial
$ command -v gpg
/usr/bin/gpg
$ command -v wget
/usr/bin/wget
$ if [[ -z $(command -v wget &> /dev/null) ]] || [[ -z $(command -v gpg &> /dev/null) ]]; then echo install; else echo pass; fi
install
$ if ! command -v wget &> /dev/null || ! command -v gpg &> /dev/null; then echo install; else echo pass; fi
pass
```