### PR TITLE
Add recipe to clean up temporary build artifacts

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -55,7 +55,7 @@ BUILD_ARGS64_BUNDLED = $(BUILD_ARGS64) \
 all: all64 ## Build all distribution tarballs [default]
 
 .PHONY: all64
-all64: compress64 ## Build distribution tarballs for 64 bits
+all64: compress64 clean_tmp ## Build distribution tarballs for 64 bits
 
 .PHONY: help
 help: ## Show this help
@@ -112,3 +112,8 @@ $(OUTPUT_DIR)/%.xz: $(OUTPUT_DIR)/%
 .PHONY: clean
 clean: ## Clean up build directory
 	rm -Rf $(OUTPUT_DIR)
+
+.PHONY: clean_tmp
+clean_tmp: ## Clean up temporary build artifacts
+	rm -Rf $(OUTPUT_DIR)/bundled-libs.tar
+	rm -Rf $(OUTPUT_BASENAME64)-bundled


### PR DESCRIPTION
There are a lot of temporary build artifcats in the build folder which get stored as artifacts in circle CI (see https://app.circleci.com/pipelines/github/crystal-lang/crystal/7078/workflows/705e8bba-b14d-4a4d-ae48-6f821f6b9548/jobs/65134/artifacts).

This new `clean_tmp` recipe removes all intermediary artifacts from `build`. It gets automatically invoked from `all64`.