### PR TITLE
Fix pcre download URL

### DIFF
--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -9,7 +9,7 @@ ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 # build libpcre
 FROM debian AS libpcre
 ARG libpcre_version
-RUN curl https://ftp.pcre.org/pub/pcre/pcre-${libpcre_version}.tar.gz | tar -zx \
+RUN curl -L https://sourceforge.net/projects/pcre/files/pcre/${libpcre_version}/pcre-${libpcre_version}.tar.gz/download | tar -zx \
  && cd pcre-${libpcre_version} \
  && ./configure --disable-shared --disable-cpp --enable-jit --enable-utf --enable-unicode-properties \
  && make -j$(nproc)

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -9,7 +9,7 @@ ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 # build libpcre
 FROM debian AS libpcre
 ARG libpcre_version
-RUN curl -L https://sourceforge.net/projects/pcre/files/pcre/${libpcre_version}/pcre-${libpcre_version}.tar.gz/download | tar -zx \
+RUN curl http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-${libpcre_version}.tar.gz | tar -zx \
  && cd pcre-${libpcre_version} \
  && ./configure --disable-shared --disable-cpp --enable-jit --enable-utf --enable-unicode-properties \
  && make -j$(nproc)

--- a/omnibus/config/software/pcre.rb
+++ b/omnibus/config/software/pcre.rb
@@ -18,7 +18,7 @@ name "pcre"
 default_version "8.40"
 skip_transitive_dependency_licensing true
 
-source url: "https://ftp.pcre.org/pub/pcre/pcre-#{version}.tar.gz",
+source url: "https://sourceforge.net/projects/pcre/files/pcre/#{version}/pcre-#{version}.tar.gz/download",
        md5: "890c808122bd90f398e6bc40ec862102"
 
 relative_path "pcre-#{version}"

--- a/omnibus/config/software/pcre.rb
+++ b/omnibus/config/software/pcre.rb
@@ -18,7 +18,7 @@ name "pcre"
 default_version "8.40"
 skip_transitive_dependency_licensing true
 
-source url: "https://sourceforge.net/projects/pcre/files/pcre/#{version}/pcre-#{version}.tar.gz/download",
+source url: "http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-#{version}.tar.gz",
        md5: "890c808122bd90f398e6bc40ec862102"
 
 relative_path "pcre-#{version}"


### PR DESCRIPTION
The server at ftp://ftp.pcre.org has been shut down. This patch changes to a different mirror for downloading libpcre.

CI workflow run: https://app.circleci.com/pipelines/github/crystal-lang/crystal/7227/workflows/f976a68c-4033-4cec-89c4-3cb88b605d23