### PR TITLE
Add libffi to build images and in the compiler build workflows

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -44,6 +44,6 @@ FROM runtime as build
 
 RUN \
   apk add --update --no-cache --force-overwrite \
-    llvm10-dev llvm10-static g++
+    llvm10-dev llvm10-static g++ libffi-dev
 
 CMD ["/bin/sh"]

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -23,7 +23,7 @@ FROM runtime as build
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm-10 lld-10 libedit-dev gdb && \
+  apt-get install -y build-essential llvm-10 lld-10 libedit-dev gdb libffi-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN ln -sf /usr/bin/ld.lld-10 /usr/bin/ld.lld

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -35,8 +35,10 @@ RUN sed -i 's|--list -- "$@"|--list "$@"|' /usr/bin/ldd
 RUN apk add --no-cache \
       # Statically-compiled llvm
       llvm10-dev llvm10-static \
-      # Static zlib, libyaml, libxml2, pcre, and libevent
+      # Static stdlib dependencies
       zlib-static yaml-static libxml2-dev pcre-dev libevent-static \
+      # Static compiler dependencies
+      libffi-dev \
       # Build tools
       git gcc g++ make automake libtool autoconf bash coreutils curl
 

--- a/omnibus/config/software/crystal.rb
+++ b/omnibus/config/software/crystal.rb
@@ -17,6 +17,7 @@ dependency "pcre"
 dependency "bdw-gc"
 dependency "llvm_bin" unless FIRST_RUN
 dependency "libevent"
+dependency "libffi"
 
 env = with_standard_compiler_flags(with_embedded_path(
   "LIBRARY_PATH" => "#{install_dir}/embedded/lib",

--- a/omnibus/config/software/libffi.rb
+++ b/omnibus/config/software/libffi.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libffi"
+default_version "3.4.2"
+
+license "MIT"
+license_file "LICENSE"
+skip_transitive_dependency_licensing true
+
+# version_list: url=https://github.com/libffi/libffi/releases filter=*.tar.gz
+
+version("3.4.2") { source sha256: "540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620" }
+
+source url: "https://github.com/libffi/libffi/releases/download/v#{version}/libffi-#{version}.tar.gz"
+
+relative_path "libffi-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  env["INSTALL"] = "/opt/freeware/bin/install" if aix?
+
+  # disable option checking as disable-docs is 3.3+ only
+  configure_command = ["--disable-option-checking",
+                       "--disable-docs",
+  ]
+
+  # AIX's old version of patch doesn't like the patch here
+  unless aix?
+    # disable multi-os-directory via configure flag (don't use /lib64)
+    # Works on all platforms, and is compatible on 32bit platforms as well
+    configure_command << "--disable-multi-os-directory"
+  end
+
+  configure(*configure_command, env: env)
+
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+
+  # libffi's default install location of header files is awful...
+  mkdir "#{install_dir}/embedded/include"
+  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
+
+end


### PR DESCRIPTION
The upcoming interpreter feature requires libffi (https://github.com/crystal-lang/crystal/pull/11475).

It's only needed in the compiler, so the regular packages don't need to ship the library. It's statically linked into the compiler.

But the build images need it in order to run specs for libffi in CI.