### PR TITLE
Add scripts for Crystal release workflow

### DIFF
--- a/processes/crystal-release.md
+++ b/processes/crystal-release.md
@@ -46,17 +46,19 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
       * Keys can be generated at https://console.aws.amazon.com/iam/home#/security_credentials (contact a Manas admin if you don't have access).
    2. Run `make -C docs publish_docs CRYSTAL_VERSION=${VERSION}` to publish docs to `api/${VERSION}`
    3. Run `make -C docs dist-redirect_latest CRYSTAL_VERSION=${VERSION}` to apply redirect from `api/latest` to `api/${VERSION}`
-2. [ ] Publish language reference (TBD)
+2. [ ] Publish language reference
+   1. Change default branch to `release/$VERSION`
 
 ### Binary releases
 
 1. [ ] Wait for the release build in circle CI
 2. [ ] Smoke test with test-ecosystem (again)
-3. [ ] Attach build artifacts to Github release
+3. [ ] Attach build artifacts from circleci and GitHub Actions (Windows) to GitHub release
    * `crystal-*-darwin-*.tar.gz`
    * `crystal-*-linux-*.tar.gz`
    * `crystal-*.pkg`
    * `crystal-*-docs.tar.gz`
+   * `crystal.zip` (GHA) -> `crystal-$VERSION-windows-x86_64-msvc-unsupported.zip`
 4. [ ] Push changes to OBS for building linux packages
    1. Checkout https://github.com/crystal-lang/distribution-scripts and go to [`./packages`](../packages)
    2. Configure build.opensuse.org credentials in environment variables:
@@ -106,6 +108,7 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
    * Edit `shell.nix` `latestCrystalBinary` using  `nix-prefetch-url --unpack <url>`
 2. [ ] Increment VERSION file to the next minor and -dev suffix
 3. [ ] Perform uncomment/todos left in the repo
+4. [ ] Update default base version in test-ecosystem
 
 ## Observable Helper
 

--- a/processes/crystal-release.md
+++ b/processes/crystal-release.md
@@ -4,16 +4,16 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
 
 ## Release preparation
 
-1. [ ] Announce expected release date and time span for feature freeze
-   * Feature freeze is about two weeks before release
-   * Set date on milestone
+1. [ ] (minor) Announce expected release date and time span for feature freeze
+   * (minor) Feature freeze is about two weeks before release
+   * (minor) Set date on milestone
 2. [ ] Start preparing changelog and release notes
-3. [ ] Start feature freeze period
-   * Either no merging of features into `master` or split off release branch for backporting bugfixes.
+3. [ ] (minor) Start feature freeze period
+   * (minor) Either no merging of features into `master` or split off release branch for backporting bugfixes.
 4. [ ] Publish release PR draft
-   * It should contain the expected date of the release (~two weeks after the PR is issued).
+   * (minor) It should contain the expected date of the release (~two weeks after the PR is issued).
    * It should be populated with updates to `CHANGELOG.md` and `VERSION`.
-5. [ ] Ensure documentation for language and compiler changes and other relevant changes is up to date.
+5. [ ] (minor) Ensure documentation for language and compiler changes and other relevant changes is up to date.
    * [Crystal Book](https://github.com/crystal-lang/crystal-book/)
       * Update language specification
       * Update compiler manual
@@ -27,17 +27,18 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
    * Make sure all changes are mentioned in the changelog
    * Check release date
    * Un-draft the PR
-2. [ ] Split off release branch (`release/x.y`)
+2. [ ] (minor) Split off release branch (`release/x.y`)
 3. [ ] Verify Maintenance CI workflow succeeds on the HEAD of the release branch
 4. [ ] Smoke test with [test-ecosystem](https://github.com/crystal-lang/test-ecosystem)
    * Run [*Test Crystal & Shards Workflow](https://github.com/crystal-lang/test-ecosystem/actions/workflows/test-crystal-shards.yml) with the release branch as `crystal_branch`.
 5. [ ] Merge the release PR
 6. [ ] Tag & annotate the commit with the changelog using `<M.m.p>` pattern as {version} (as a pre-release directly in GH?)
    * `git tag -s -a -m $VERSION $VERSION`
-7. [ ] Publish Github release
+7. [ ] Publish Github release (https://github.com/crystal-lang/crystal/releases/new)
    1. Copy the changelog section as description
    1. Binaries are added later
-8. [ ] Close milestone
+8. [ ] Close milestone (https://github.com/crystal-lang/crystal/milestones)
+9. [ ] Wait for the release build in circle CI (https://app.circleci.com/pipelines/github/crystal-lang/crystal)
 
 ### Publish documentation for the release
 
@@ -46,12 +47,11 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
       * Keys can be generated at https://console.aws.amazon.com/iam/home#/security_credentials (contact a Manas admin if you don't have access).
    2. Run `make -C docs publish_docs CRYSTAL_VERSION=${VERSION}` to publish docs to `api/${VERSION}`
    3. Run `make -C docs dist-redirect_latest CRYSTAL_VERSION=${VERSION}` to apply redirect from `api/latest` to `api/${VERSION}`
-2. [ ] Publish language reference
-   1. Change default branch to `release/$VERSION`
+2. [ ] (minor) Publish language reference
+   1. (minor) Change default branch to `release/$VERSION`
 
 ### Binary releases
 
-1. [ ] Wait for the release build in circle CI
 2. [ ] Smoke test with test-ecosystem (again)
 3. [ ] Attach build artifacts from circleci and GitHub Actions (Windows) to GitHub release
    * `crystal-*-darwin-*.tar.gz`
@@ -70,6 +70,7 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
       * You can also run the commands from that file manually and check build locally with
          * `osc build xUbuntu_20.04 x86_64`
          * `osc build Fedora_Rawhide x86_64`
+   4. Run [`./obs-release.sh devel:languages:crystal crystal${VERSION%.*} $VERSION`](../packages/obs-release.sh)
    4. Now OBS builds the packages. It’s best to follow the build status in the browser:
       1. `open https://build.opensuse.org/project/show/home:$OBS_USER:branches:devel:langauges:crystal/crystal`
       1. Wait for all package build jobs to finish and succeed
@@ -106,14 +107,6 @@ Add an issue `Crystal release X.Y.Z` in this repo with a copy of this document. 
    * Edit `prepare_build` on_osx download package and folder
    * Edit ` .github/workflows/*.yml` to point to docker image
    * Edit `shell.nix` `latestCrystalBinary` using  `nix-prefetch-url --unpack <url>`
-2. [ ] Increment VERSION file to the next minor and -dev suffix
-3. [ ] Perform uncomment/todos left in the repo
+2. [ ] (minor) Increment VERSION file to the next minor and -dev suffix
+3. [ ] (minor) Perform uncomment/todos left in the repo
 4. [ ] Update default base version in test-ecosystem
-
-## Observable Helper
-
-Build changelog lines
-https://observablehq.com/d/035be530d554ccdf
-
-Check commit history
-https://observablehq.com/d/4937e5db876fe1d4

--- a/processes/scripts/functions.sh
+++ b/processes/scripts/functions.sh
@@ -1,0 +1,27 @@
+START_STEP=${START_STEP:-1}
+step_number=1
+
+step(){
+  message="$1"
+  shift
+  command="$*"
+
+  echo
+  echo "\033[33m===============================================================================\033[0m"
+  echo "\033[33m$step_number. $message\033[0m"
+  echo
+  echo -n "$ $command"
+  step_number=$(expr $step_number + 1)
+  if [ $step_number -lt $START_STEP ]; then
+    echo " \033[33m(skipped)\033[0m"
+    return
+  fi
+
+  read -r REPLY
+
+  if [ "$REPLY" != "skip" ]; then
+    eval "$command"
+  else
+    echo "\033[33m(skipped)\033[0m"
+  fi
+}

--- a/processes/scripts/make-crystal-release.sh
+++ b/processes/scripts/make-crystal-release.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+#
+# This helper tags a new Crystal release and publishes it to GitHub releases.
+#
+# Usage:
+#
+#    scripts/make-crystal-release.sh [VERSION]
+#
+# Requirements:
+# * packages: git gh sed wget
+# * Working directory should be in a checked out work tree of `crystal-lang/crystal`.
+#
+# * The version is read from `src/VERSION`.
+# * Tags current commit and pushes tag to GitHub.
+# * Creates GitHub release for that tag with content from `CHANGELOG.md`.
+# * Pulls release artifacts from CI and attaches them to the GitHub release.
+
+set -eu
+
+VERSION=$(cat src/VERSION | tr -d '\n')
+START_STEP=${1:-1}
+
+. $(dirname $(realpath $0))/functions.sh
+
+step "Tag master commit as version ${VERSION}" git tag -s -a -m $VERSION $VERSION
+
+git show
+
+step "Push tag to GitHub" git push --tags
+
+sed -E '3,/^# /!d' CHANGELOG.md | sed '$d' | sed -Ez 's/^\n+//; s/\n+$/\n/g' > CHANGELOG.$VERSION.md
+
+echo "$ more CHANGELOG.$VERSION.md"
+more CHANGELOG.$VERSION.md
+
+step "Create GitHub release" gh release -R crystal-lang/crystal create $VERSION --title $VERSION --notes-file CHANGELOG.$VERSION.md
+
+step "Wait for CI workflow to build artifacts ☕" echo
+
+read -p "CircleCI artifact URL (one example): " circle_artifact_url
+
+artifacts_dir=/tmp/artifacts-crystal-$VERSION
+mkdir -p $artifacts_dir
+rm -fr $artifacts_dir/*
+
+wget --directory-prefix=$artifacts_dir/ \
+  ${circle_artifact_url%/*}/crystal-$VERSION-1-darwin-universal.tar.gz \
+  ${circle_artifact_url%/*}/crystal-$VERSION-1-linux-x86_64-bundled.tar.gz \
+  ${circle_artifact_url%/*}/crystal-$VERSION-1-linux-x86_64.tar.gz \
+  ${circle_artifact_url%/*}/crystal-$VERSION-1.universal.pkg \
+  ${circle_artifact_url%/*}/crystal-$VERSION-docs.tar.gz | more
+
+ls -lh $artifacts_dir/
+
+step "Upload artifacts to GitHub release $VERSION" gh release -R crystal-lang/crystal upload $VERSION $artifacts_dir/*

--- a/processes/scripts/prepare-crystal-release.sh
+++ b/processes/scripts/prepare-crystal-release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+#
+# This helper creates a new release issue for Crystal
+#
+# Usage:
+#
+#    scripts/prepare-crystal-release.sh VERSION
+#
+# The content is generated from Crystal release checklist (../crystal-release.md)
+# with filters applied based on the version type (major, minor, or patch).
+
+set -eu
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 VERSION"
+  exit 1
+fi
+
+VERSION=$1
+
+. $(dirname $(realpath $0))/functions.sh
+
+case $VERSION in
+  *.0.0)
+    TYPE=major
+  ;;
+  *.0)
+    TYPE=minor
+  ;;
+  *)
+    TYPE=patch
+  ;;
+esac
+
+dist_scripts_root=$(dirname $(dirname $(dirname $(realpath $0))))
+
+body=$(sed -E '/^##/,$!d' $dist_scripts_root/processes/crystal-release.md)
+
+case $TYPE in
+  patch)
+    body=$(echo "$body" | sed -E "/\(major\)/d;/\(minor\)/d;s/\(patch\)\s*//")
+  ;;
+  minor)
+    body=$(echo "$body" | sed -E "/\(major\)/d;s/\(minor\)\s*//;/\(patch\)/d")
+  ;;
+  major)
+    body=$(echo "$body" | sed -E "s/\(major\)\s*//;s/\(minor\)\s*//;/\(patch\)/d")
+  ;;
+esac
+
+step "Create tracking issue in crystal-lang/distribution-scripts" gh issue create -R crystal-lang/distribution-scripts --body "\"$body\"" --label "release" --title \"Release Crystal $VERSION\"


### PR DESCRIPTION
This patch adds two scripts that automate parts of Crystal's release workflow.

* `prepare-crystal-release` creates a tracking issue for the release in this repository (#177 was created by that script)
* `make-crystal-release` tags the git commit, pushes it it to GitHub and attaches artifacts when CI is finished (https://github.com/crystal-lang/crystal/releases/tag/1.3.2 was created by that script).