### PR TITLE
Fix libpcre source download

### DIFF
--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -9,7 +9,7 @@ ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 # build libpcre
 FROM debian AS libpcre
 ARG libpcre_version
-RUN curl http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-${libpcre_version}.tar.gz | tar -zx \
+RUN curl https://ftp.exim.org/pub/pcre/pcre-${libpcre_version}.tar.gz | tar -zx \
  && cd pcre-${libpcre_version} \
  && ./configure --disable-shared --disable-cpp --enable-jit --enable-utf --enable-unicode-properties \
  && make -j$(nproc)

--- a/omnibus/config/software/pcre.rb
+++ b/omnibus/config/software/pcre.rb
@@ -18,7 +18,7 @@ name "pcre"
 default_version "8.40"
 skip_transitive_dependency_licensing true
 
-source url: "http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-#{version}.tar.gz",
+source url: "https://ftp.exim.org/pub/pcre/pcre-#{version}.tar.gz",
        md5: "890c808122bd90f398e6bc40ec862102"
 
 relative_path "pcre-#{version}"


### PR DESCRIPTION
`nightly_release` workflow is broken on CircleCI https://app.circleci.com/pipelines/github/crystal-lang/crystal/9033/workflows/6c7f40b6-9f7b-463d-9583-da4952037a74

The server at `http://ftp.cs.stanford.edu` is missing pcre tarball.

This patch changes to an official exim mirror for PCRE.