### PR TITLE
Reorganize crystal release instructions for helper scripts

### DIFF
--- a/processes/crystal-release.md
+++ b/processes/crystal-release.md
@@ -24,7 +24,6 @@ Add an issue `Crystal release X.Y.Z` in https://github.com/crystal-lang/distribu
 
 ### Source release
 
-*Steps "Tag & annotate" and "Publish Github release" are automated via
 
 1. [ ] Finalize the release PR
    * Make sure all changes are mentioned in the changelog

--- a/processes/scripts/make-crystal-release.sh
+++ b/processes/scripts/make-crystal-release.sh
@@ -7,13 +7,12 @@
 #    scripts/make-crystal-release.sh
 #
 # Requirements:
-# * packages: git gh sed wget
+# * packages: git gh sed
 # * Working directory should be in a checked out work tree of `crystal-lang/crystal`.
 #
 # * The version is read from `src/VERSION`.
 # * Tags current commit and pushes tag to GitHub.
 # * Creates GitHub release for that tag with content from `CHANGELOG.md`.
-# * Pulls release artifacts from CI and attaches them to the GitHub release.
 
 set -eu
 
@@ -38,20 +37,3 @@ step "Create GitHub release" gh release -R crystal-lang/crystal create $VERSION 
 rm CHANGELOG.$VERSION.md
 
 step "Wait for CI workflow to build artifacts ☕" echo
-
-read -p "CircleCI artifact URL (one example): " circle_artifact_url
-
-artifacts_dir=/tmp/artifacts-crystal-$VERSION
-mkdir -p $artifacts_dir
-rm -fr $artifacts_dir/*
-
-wget --directory-prefix=$artifacts_dir/ \
-  ${circle_artifact_url%/*}/crystal-$VERSION-1-darwin-universal.tar.gz \
-  ${circle_artifact_url%/*}/crystal-$VERSION-1-linux-x86_64-bundled.tar.gz \
-  ${circle_artifact_url%/*}/crystal-$VERSION-1-linux-x86_64.tar.gz \
-  ${circle_artifact_url%/*}/crystal-$VERSION-1.universal.pkg \
-  ${circle_artifact_url%/*}/crystal-$VERSION-docs.tar.gz | more
-
-ls -lh $artifacts_dir/
-
-step "Upload artifacts to GitHub release $VERSION" gh release -R crystal-lang/crystal upload $VERSION $artifacts_dir/*

--- a/processes/scripts/publish-crystal-packages-on-github.sh
+++ b/processes/scripts/publish-crystal-packages-on-github.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+#
+# This helper pulls binary build artifacts from the release workflow and publishes them to the GitHub release.
+#
+# Usage:
+#
+#    scripts/publish-crystal-packages-on-github.sh CIRCLECI_ARTIFACT_URL
+#
+# Arguments:
+#
+#   CIRCLECI_ARTIFACT_URL: URL to a binary artifact from the CircleCI release workflow (`dist_artifact` job).
+#                          Any URL suffices as an example, the script just needs that to pull the path prefix
+#                          and will download all artifacts, not just the given URL.
+#
+# Requirements:
+# * packages: gh wget
+#
+# * The version is read from `$VERSION` or `src/VERSION`.
+# * Pulls release artifacts from CI and attaches them to the GitHub release.
+
+set -eu
+
+VERSION=${VERSION:-$(cat src/VERSION | tr -d '\n')}
+START_STEP=${START_STEP:-1}
+
+circle_artifact_url=${1}
+
+. $(dirname $(realpath $0))/functions.sh
+
+artifacts_dir=/tmp/artifacts-crystal-$VERSION
+mkdir -p "$artifacts_dir"
+rm -rf "$artifacts_dir/*"
+
+wget --directory-prefix="$artifacts_dir/" \
+  "${circle_artifact_url%/*}/crystal-$VERSION-1-darwin-universal.tar.gz" \
+  "${circle_artifact_url%/*}/crystal-$VERSION-1-linux-x86_64-bundled.tar.gz" \
+  "${circle_artifact_url%/*}/crystal-$VERSION-1-linux-x86_64.tar.gz" \
+  "${circle_artifact_url%/*}/crystal-$VERSION-1.universal.pkg" \
+  "${circle_artifact_url%/*}/crystal-$VERSION-docs.tar.gz" | more
+
+ls -lh "$artifacts_dir/"
+
+step "Upload artifacts to GitHub release $VERSION" gh release -R crystal-lang/crystal upload $VERSION "$artifacts_dir/*"
+
+rm -rf "$artifacts_dir"


### PR DESCRIPTION
* Highlights the automation scripts more as instructions to run them instead of facultative helpers.
* Reorders instructions for documentation after the binary release because we need the binary on GitHub releases for building crystal-book.
* Extracts the step for publishing binary artifacts from CircleCI to GitHub releases into a separate script.
* Clarifies when to use the full version including patch number and when only major and minor.

