### PR TITLE
Upgrade Linux build environment to LLVM 13

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -11,9 +11,6 @@ ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 ENV CC="clang-8"
 
-# Termporary pinning libcurl oldrelease because current (7.74.0) is broken
-RUN apt-get install -y --allow-downgrades libcurl3-gnutls=7.64.0-4+deb10u2
-
 # Build libgc
 ARG gc_version
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -2,9 +2,8 @@ ARG alpine_image
 ARG debian_image
 FROM ${debian_image} AS debian
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list \
- && apt-get update \
- && apt-get install -y -t buster-backports build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-8 clang-8 \
+RUN apt-get update \
+ && apt-get install -y build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-8 clang-8 \
  && (pkg-config || true)
 
 ARG release

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -71,7 +71,7 @@ RUN git clone https://github.com/crystal-lang/crystal \
  \
  && make crystal stats=true static=true ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} \
- && ([ "$(ldd .build/crystal | wc -l)" -eq "1" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
+ && ([ "$(ldd .build/crystal 2>&1 | wc -l)" -eq "1" ] || { echo './build/crystal is not statically linked'; ldd .build/crystal; exit 1; })
 
 # Build shards
 ARG shards_version
@@ -84,7 +84,7 @@ RUN git clone https://github.com/crystal-lang/shards \
  && make SHARDS=false CRYSTAL=/crystal/bin/crystal \
          FLAGS="--stats --target ${musl_target} --static ${release:+--release}" \
  \
- && ([ "$(ldd bin/shards | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd bin/shards; exit 1; })
+ && ([ "$(ldd bin/shards 2>&1 | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd bin/shards; exit 1; })
 
 COPY --from=debian /bdwgc/.libs/libgc.a /libgc-debian.a
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -26,8 +26,6 @@ RUN git clone https://github.com/ivmai/bdwgc \
 
 FROM ${alpine_image}
 
-RUN sed -i 's|--list -- "$@"|--list "$@"|' /usr/bin/ldd
-
 # Install dependencies
 RUN apk add --no-cache \
       # Statically-compiled llvm

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -3,12 +3,12 @@ ARG debian_image
 FROM ${debian_image} AS debian
 
 RUN apt-get update \
- && apt-get install -y build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-8 clang-8 \
+ && apt-get install -y build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-13 clang-13 \
  && (pkg-config || true)
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
-ENV CC="clang-8"
+ENV CC="clang-13"
 
 # Build libgc
 ARG gc_version
@@ -25,7 +25,7 @@ FROM ${alpine_image}
 # Install dependencies
 RUN apk add --no-cache \
       # Statically-compiled llvm
-      llvm10-dev llvm10-static \
+      llvm13-dev llvm13-static \
       # Static stdlib dependencies
       zlib-static yaml-static libxml2-dev pcre-dev libevent-static \
       # Static compiler dependencies

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,6 +1,4 @@
-ARG alpine_image
-ARG debian_image
-FROM ${debian_image} AS debian
+FROM debian:11 AS debian
 
 RUN apt-get update \
  && apt-get install -y build-essential libevent-dev libpcre3-dev automake libtool pkg-config git curl llvm-13 clang-13 \
@@ -20,7 +18,7 @@ RUN git clone https://github.com/ivmai/bdwgc \
  && ./configure --disable-debug --disable-shared --enable-large-config \
  && make -j$(nproc)
 
-FROM ${alpine_image}
+FROM alpine:3.16
 
 # Install dependencies
 RUN apk add --no-cache \

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -40,8 +40,6 @@ BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
 
 BUILD_ARGS64 = $(BUILD_ARGS_COMMON) \
                --build-arg previous_crystal_release=$(PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ)	\
-               --build-arg debian_image=debian:11 \
-               --build-arg alpine_image=alpine:3.16 \
                --build-arg musl_target=x86_64-linux-musl \
                --build-arg gnu_target=x86_64-unknown-linux-gnu
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -21,7 +21,7 @@ PREVIOUS_CRYSTAL_PACKAGE_ITERATION ?= 1## Package iteration of the bootstrap com
 PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ ?= https://github.com/crystal-lang/crystal/releases/download/$(PREVIOUS_CRYSTAL_VERSION)/crystal-$(PREVIOUS_CRYSTAL_VERSION)-$(PREVIOUS_CRYSTAL_PACKAGE_ITERATION)-linux-x86_64.tar.gz ## url to crystal-{version}-{package}-linux-x86_64.tar.gz
 
 SHARDS_VERSION = v0.17.0
-GC_VERSION = v8.2.0
+GC_VERSION = v8.2.2
 LIBPCRE_VERSION = 8.45
 LIBEVENT_VERSION = release-2.1.12-stable
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -41,7 +41,7 @@ BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
 BUILD_ARGS64 = $(BUILD_ARGS_COMMON) \
                --build-arg previous_crystal_release=$(PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ)	\
                --build-arg debian_image=debian:10 \
-               --build-arg alpine_image=alpine:3.12 \
+               --build-arg alpine_image=alpine:3.16 \
                --build-arg musl_target=x86_64-linux-musl \
                --build-arg gnu_target=x86_64-unknown-linux-gnu
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -40,7 +40,7 @@ BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
 
 BUILD_ARGS64 = $(BUILD_ARGS_COMMON) \
                --build-arg previous_crystal_release=$(PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ)	\
-               --build-arg debian_image=debian:10 \
+               --build-arg debian_image=debian:11 \
                --build-arg alpine_image=alpine:3.16 \
                --build-arg musl_target=x86_64-linux-musl \
                --build-arg gnu_target=x86_64-unknown-linux-gnu

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -1,5 +1,4 @@
-ARG debian_image
-FROM ${debian_image} AS debian
+FROM debian:11 AS debian
 
 RUN apt-get update \
  && apt-get install -y curl build-essential git automake libtool pkg-config


### PR DESCRIPTION
This upgrades several components of the Linux build environment:

* alpine:3:12 -> alpine:3.16
* debian:10 -> debian:11
* bdwgc 8.2.0 -> bdwgc 8.2.2
* LLVM 11 -> LLVM 13

Green CI workflow: https://app.circleci.com/pipelines/github/crystal-lang/crystal/9794/workflows/5f762e48-3920-4242-abc1-f4c4685c0a47

Resolves #147