### PR TITLE
Update to libpcre2

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.16 as runtime
 RUN \
   apk add --update --no-cache --force-overwrite \
     # core dependencies
-    gcc gmp-dev libevent-static musl-dev pcre-dev \
+    gcc gmp-dev libevent-static musl-dev pcre2-dev \
     # stdlib dependencies
     libxml2-dev openssl-dev openssl-libs-static tzdata yaml-static zlib-static \
     # dev tools

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.16 as runtime
 RUN \
   apk add --update --no-cache --force-overwrite \
     # core dependencies
-    gcc gmp-dev libevent-static musl-dev pcre2-dev \
+    gcc gmp-dev libevent-static musl-dev pcre-dev pcre2-dev \
     # stdlib dependencies
     libxml2-dev openssl-dev openssl-libs-static tzdata yaml-static zlib-static \
     # dev tools

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y tzdata gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make \
-                     libpcre2-dev libevent-dev libz-dev && \
+                     libpcre3-dev libpcre2-dev libevent-dev libz-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG crystal_targz

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y tzdata gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make \
-                     libpcre3-dev libevent-dev libz-dev && \
+                     libpcre2-dev libevent-dev libz-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG crystal_targz

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -22,7 +22,7 @@ PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ ?= https://github.com/crystal-lang/crysta
 
 SHARDS_VERSION = v0.17.2
 GC_VERSION = v8.2.2
-LIBPCRE_VERSION = 8.45
+LIBPCRE2_VERSION = 10.42
 LIBEVENT_VERSION = release-2.1.12-stable
 
 OUTPUT_DIR = build
@@ -44,7 +44,7 @@ BUILD_ARGS64 = $(BUILD_ARGS_COMMON) \
                --build-arg gnu_target=x86_64-unknown-linux-gnu
 
 BUILD_ARGS64_BUNDLED = $(BUILD_ARGS64) \
-               --build-arg libpcre_version=$(LIBPCRE_VERSION) \
+               --build-arg libpcre2_version=$(LIBPCRE2_VERSION) \
                --build-arg libevent_version=$(LIBEVENT_VERSION)
 
 .PHONY: all

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -8,7 +8,7 @@ ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 # build libpcre2
 FROM debian AS libpcre2
 ARG libpcre2_version
-RUN curl https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${libpcre2_version}/pcre2-${libpcre2_version}.tar.gz | tar -zx \
+RUN curl -L https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${libpcre2_version}/pcre2-${libpcre2_version}.tar.gz | tar -zx \
  && cd pcre2-${libpcre2_version} \
  && ./configure --disable-shared --disable-cpp --enable-jit --enable-utf --enable-unicode-properties \
  && make -j$(nproc)

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -33,7 +33,7 @@ ARG libevent_version
 RUN mkdir -p /output/lib/crystal/lib/
 
 # Copy libraries
-COPY --from=libpcre pcre-${libpcre_version}/.libs/libpcre.a /output/lib/crystal/
+COPY --from=libpcre2 pcre-${libpcre2_version}/.libs/libpcre2-8.a /output/lib/crystal/
 COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/
 
 # Create tarball

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -33,8 +33,8 @@ ARG libevent_version
 RUN mkdir -p /output/lib/crystal/lib/
 
 # Copy libraries
-COPY --from=libpcre2 pcre2-${libpcre2_version}/.libs/libpcre2-8.a /output/lib/crystal/lib/
-COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/lib/
+COPY --from=libpcre2 pcre2-${libpcre2_version}/.libs/libpcre2-8.a /output/lib/crystal/
+COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/
 
 # Create tarball
 RUN mv /output /crystal-${crystal_version}-${package_iteration} \

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -5,11 +5,11 @@ RUN apt-get update \
 
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 
-# build libpcre
-FROM debian AS libpcre
-ARG libpcre_version
-RUN curl https://ftp.exim.org/pub/pcre/pcre-${libpcre_version}.tar.gz | tar -zx \
- && cd pcre-${libpcre_version} \
+# build libpcre2
+FROM debian AS libpcre2
+ARG libpcre2_version
+RUN curl https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${libpcre2_version}/pcre2-${libpcre2_version}.tar.gz | tar -zx \
+ && cd pcre2-${libpcre2_version} \
  && ./configure --disable-shared --disable-cpp --enable-jit --enable-utf --enable-unicode-properties \
  && make -j$(nproc)
 
@@ -27,13 +27,13 @@ RUN git clone https://github.com/libevent/libevent \
 FROM debian
 ARG crystal_version
 ARG package_iteration
-ARG libpcre_version
+ARG libpcre2_version
 ARG libevent_version
 
 RUN mkdir -p /output/lib/crystal/lib/
 
 # Copy libraries
-COPY --from=libpcre pcre-${libpcre_version}/.libs/libpcre.a /output/lib/crystal/lib/
+COPY --from=libpcre2 pcre2-${libpcre2_version}/.libs/libpcre2-8.a /output/lib/crystal/lib/
 COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/lib/
 
 # Create tarball

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -33,7 +33,7 @@ ARG libevent_version
 RUN mkdir -p /output/lib/crystal/lib/
 
 # Copy libraries
-COPY --from=libpcre2 pcre-${libpcre2_version}/.libs/libpcre2-8.a /output/lib/crystal/
+COPY --from=libpcre2 pcre2-${libpcre2_version}/.libs/libpcre2-8.a /output/lib/crystal/
 COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/
 
 # Create tarball

--- a/snapcraft/README.md
+++ b/snapcraft/README.md
@@ -44,7 +44,7 @@ The following are the suggested packages to be able to use the whole standard li
 
 ```
 $ sudo apt-get install gcc pkg-config git tzdata \
-                       libpcre3-dev libevent-dev libyaml-dev \
+                       libpcre2-dev libevent-dev libyaml-dev \
                        libgmp-dev libssl-dev libxml2-dev
 ```
 

--- a/snapcraft/crystal-snap-wrapper
+++ b/snapcraft/crystal-snap-wrapper
@@ -14,7 +14,7 @@ if [ ! -f $SNAP_USER_COMMON/env-check-success ]; then
   The following are the suggested packages to be able to use the whole standard library capabilities.
 
     $ sudo apt-get install gcc pkg-config git tzdata \\
-                           libpcre3-dev libevent-dev libyaml-dev \\
+                           libpcre2-dev libevent-dev libyaml-dev \\
                            libgmp-dev libssl-dev libxml2-dev
 
   You can find more detailed information in:


### PR DESCRIPTION
This is a part of the effort to migrate the regex engine to PCRE2 (https://github.com/crystal-lang/crystal/issues/12790).

With https://github.com/crystal-lang/crystal/pull/12978, PCRE2 becomes the default engine at which point we should ship libpcre2 in the packages where we distribute the regex library.
That's the bundled tarball and the docker images.