### PR TITLE
Fix lib locations in bundled tarball

### DIFF
--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -33,8 +33,8 @@ ARG libevent_version
 RUN mkdir -p /output/lib/crystal/lib/
 
 # Copy libraries
-COPY --from=libpcre pcre-${libpcre_version}/.libs/libpcre.a /output/lib/crystal/lib/
-COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/lib/
+COPY --from=libpcre pcre-${libpcre_version}/.libs/libpcre.a /output/lib/crystal/
+COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.a /output/lib/crystal/
 
 # Create tarball
 RUN mv /output /crystal-${crystal_version}-${package_iteration} \


### PR DESCRIPTION
The additional libs in the bundled tarball (libevent and libpcre) are placed in a subfolder of the lib path that the compiler looks up making them inaccessible.
These files should be placed alongside `libgc` which is also included in the normal tarball.

```console
$ tree crystal-1.7.2-1/lib
crystal-1.7.2-1/lib
└── crystal
    ├── bin -> ../../bin
    ├── lib
    │   ├── libevent.a
    │   ├── libevent_pthreads.a
    │   └── libpcre.a
    └── libgc.a

4 directories, 4 files
```