### PR TITLE
Bugfix: comments in variables values create spaces

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,10 +10,9 @@
 CRYSTAL_VERSION ?=   ## How the binaries should be branded
 CRYSTAL_DEB ?=       ## Which crystal.deb file to install in debian based docker images (ubuntu32)
 CRYSTAL_TARGZ ?=     ## Which crystal.tar.gz file to install in docker images (ubuntu64, alpine)
-## How to tag the docker image (examples: `0.27.2`, `nightly20190307`). `-build` will be appended for build images.
-DOCKER_TAG ?= $(CRYSTAL_VERSION)
-## Docker hub repository to commit image
-DOCKER_REPOSITORY ?= crystallang/crystal
+
+DOCKER_TAG ?= $(CRYSTAL_VERSION)## How to tag the docker image (examples: `0.27.2`, `nightly20190307`). `-build` will be appended for build images.
+DOCKER_REPOSITORY ?= crystallang/crystal## Docker hub repository to commit image
 
 GC_VERSION = v8.2.0
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,8 +10,10 @@
 CRYSTAL_VERSION ?=   ## How the binaries should be branded
 CRYSTAL_DEB ?=       ## Which crystal.deb file to install in debian based docker images (ubuntu32)
 CRYSTAL_TARGZ ?=     ## Which crystal.tar.gz file to install in docker images (ubuntu64, alpine)
-DOCKER_TAG ?= $(CRYSTAL_VERSION) ## How to tag the docker image (examples: `0.27.2`, `nightly20190307`). `-build` will be appended for build images.
-DOCKER_REPOSITORY ?= crystallang/crystal ## Docker hub repository to commit image
+## How to tag the docker image (examples: `0.27.2`, `nightly20190307`). `-build` will be appended for build images.
+DOCKER_TAG ?= $(CRYSTAL_VERSION)
+## Docker hub repository to commit image
+DOCKER_REPOSITORY ?= crystallang/crystal
 
 GC_VERSION = v8.2.0
 


### PR DESCRIPTION
In a `Makefile` a line of the sort `VAR = VAL  ## comment` makes `VAR` have `VAL ` (note the space). This is documented in the [GNU man of make](https://www.gnu.org/software/make/manual/make.html#Flavors).

> Conversely, if you do not want any whitespace characters at the end of your variable value, you must remember not to put a random comment on the end of the line after some whitespace, such as this:
>
> `dir := /foo/bar    # directory to put the frobs in`
>
> Here the value of the variable dir is ‘/foo/bar    ’ (with four trailing spaces), which was probably not the intention.