### PR TITLE
Processes: Narrow down query for PRs without milestone

### DIFF
--- a/processes/crystal-release.md
+++ b/processes/crystal-release.md
@@ -8,7 +8,7 @@ Add an issue `Crystal release X.Y.Z` in https://github.com/crystal-lang/distribu
    * (minor) Feature freeze is about two weeks before release
    * (minor) Set date on milestone
 2. [ ] Prepare the changelog entry: [`crystal:scripts/github-changelog.cr`](https://github.com/crystal-lang/crystal/blob/master/scripts/github-changelog.cr)
-   * Ensure that all merged PRs are added to the milestone (check [`is:pr is:merged sort:updated-desc no:milestone`](https://github.com/crystal-lang/crystal/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+no%3Amilestone)).
+   * Ensure that all merged PRs are added to the milestone (check [`is:pr is:merged sort:updated-desc no:milestone`](https://github.com/crystal-lang/crystal/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+no%3Amilestone+-label%3Astatus%3Areverted+base%3Amaster+merged%3A%3E%3D2023-01-01)).
    * Ensure that all milestoned PRs are properly labelled (check [`is:pr is:merged sort:updated-desc no:label milestone:${VERSION}`](https://github.com/crystal-lang/crystal/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+milestone%3A${VERSION}+no%3Alabel)).
 3. [ ] Start preparing release notes
 3. [ ] (minor) Start feature freeze period


### PR DESCRIPTION
The link now points to https://github.com/crystal-lang/crystal/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+no%3Amilestone+-label%3Astatus%3Areverted+base%3Amaster+merged%3A%3E%3D2023-01-01 and excludes label `status:reverted`, PRs that were not merged to `master` and old ones.