### PR TITLE
Build PCRE2 with JIT mode enabled on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ omnibus/.bundle
 omnibus/bin
 omnibus/crystal-darwin-*
 omnibus/shards-darwin-*
+omnibus/vendor
 
 docs/build/
 

--- a/omnibus/config/software/pcre2.rb
+++ b/omnibus/config/software/pcre2.rb
@@ -25,7 +25,7 @@ relative_path "pcre2-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env["CFLAGS"] << " -fPIC -arch arm64 -arch x86_64"
+  env["CFLAGS"] << " -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC -arch arm64 -arch x86_64"
   env["CPPFLAGS"] = env["CPPFLAGS"].gsub("-arch arm64 -arch x86_64", "")
 
   command "./configure" \
@@ -33,9 +33,8 @@ build do
           " --disable-cpp" \
           " --disable-shared" \
           " --enable-unicode-properties" \
-          " --enable-utf", env: env
-          # TODO: Enable JIT (Error: "Must target Big Sur or newer")
-          # " --enable-jit" \
+          " --enable-utf" \
+          " --enable-jit", env: env
 
   make "-j #{workers}", env: env
   make "install", env: env


### PR DESCRIPTION
- Build PCRE2 with JIT mode enabled on mac (13.2.1)
- Drop support for OSX < 11.0
- Add `omnibus/vendor` to `.gitignore`

```sh
$ ruby --version
ruby 2.7.7p221 (2022-11-24 revision 168ec2b1e5) [x86_64-darwin22]
```

Omnibus successfully built PCRE2 on my mac with this change:
```text
[Builder: pcre2] I | 2023-03-17T13:13:05-04:00 |   PKG_CONFIG_PATH="/opt/crystal/embedded/lib/pkgconfig"
[Builder: pcre2] I | 2023-03-17T13:13:05-04:00 | $ ./configure --prefix=/opt/crystal/embedded --disable-cpp --disable-shared --enable-unicode-properties --enable-utf --enable-jit
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 | Execute: `./configure --prefix=/opt/crystal/embedded --disable-cpp --disable-shared --enable-unicode-properties --enable-utf --enable-jit': 27.8581s
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 | Environment:
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   CFLAGS="-I/opt/crystal/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC -arch arm64 -arch x86_64"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   CPPFLAGS="-I/opt/crystal/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC "
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   CXXFLAGS="-I/opt/crystal/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC -arch arm64 -arch x86_64"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   LDFLAGS="-Wl,-rpath,/opt/crystal/embedded/lib -L/opt/crystal/embedded/lib"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   LD_RUN_PATH="/opt/crystal/embedded/lib"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   OMNIBUS_INSTALL_DIR="/opt/crystal"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   PATH="<redacted>"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 |   PKG_CONFIG_PATH="/opt/crystal/embedded/lib/pkgconfig"
[Builder: pcre2] I | 2023-03-17T13:13:33-04:00 | $ make -j 17
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 | Execute: `make -j 17': 24.9378s
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 | Environment:
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   CFLAGS="-I/opt/crystal/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC -arch arm64 -arch x86_64"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   CPPFLAGS="-I/opt/crystal/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC "
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   CXXFLAGS="-I/opt/crystal/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector -DMAC_OS_X_VERSION_MIN_REQUIRED=110000 -fPIC -arch arm64 -arch x86_64"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   LDFLAGS="-Wl,-rpath,/opt/crystal/embedded/lib -L/opt/crystal/embedded/lib"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   LD_RUN_PATH="/opt/crystal/embedded/lib"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   OMNIBUS_INSTALL_DIR="/opt/crystal"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   PATH="<redacted>"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 |   PKG_CONFIG_PATH="/opt/crystal/embedded/lib/pkgconfig"
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 | $ make install
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 | Execute: `make install': 0.5981s
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 | Build pcre2: 53.3974s
[Builder: pcre2] I | 2023-03-17T13:13:58-04:00 | Finished build
```

But the build ultimately failed, for I'd assume due to an unrelated/known issue:

```text
Output:

    ./bin/crystal --release --stats -o /opt/crystal/embedded/bin/crystal src/compiler/crystal.cr
Using compiled compiler at .build/crystal

Error:

    Error: unknown command: --release
make[1]: *** [/opt/crystal/embedded/bin/crystal] Error 1
```

Resolves #228 