### PR TITLE
Add libxml2 and xz static packages

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -6,7 +6,7 @@ RUN \
     # core dependencies
     gcc gmp-dev libevent-static musl-dev pcre-dev pcre2-dev \
     # stdlib dependencies
-    libxml2-dev openssl-dev openssl-libs-static tzdata yaml-static zlib-static \
+    libxml2-dev libxml2-static openssl-dev openssl-libs-static tzdata yaml-static zlib-static xz-static \
     # dev tools
     make git \
     # build libgc dependencies


### PR DESCRIPTION
Resolves #241 

In the release notes I also noticed they mentioned openssl3 is now the default. I don't think we have to do anything specific related to that, but just pointing it out.