### PR TITLE
Fix: Install `asciidoctor` in linux build image

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
       # Static compiler dependencies
       libffi-dev \
       # Build tools
-      git gcc g++ make automake libtool autoconf bash coreutils curl
+      git gcc g++ make automake libtool autoconf bash coreutils curl asciidoctor
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"


### PR DESCRIPTION
The build job complains about missing `asciidoctor` for compiling shards' man pages.
https://app.circleci.com/pipelines/github/crystal-lang/crystal/12631/workflows/68d1c081-336a-4ecc-b6e8-e4fb3852e8ab/jobs/77518

I don't know why this only became a problem now and hadn't been an issue before.
Maybe some other dependency pulled in asciidoctor previously and now doesn't anymore? But I can't tell which one that might be.