### PR TITLE
Revert "Build universal binary for `libffi`"

### DIFF
--- a/omnibus/config/software/libffi.rb
+++ b/omnibus/config/software/libffi.rb
@@ -31,8 +31,6 @@ relative_path "libffi-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env["CFLAGS"] << " -fPIC -arch arm64 -arch x86_64"
-  env["CPPFLAGS"] = env["CPPFLAGS"].gsub("-arch arm64 -arch x86_64", "")
 
   env["INSTALL"] = "/opt/freeware/bin/install" if aix?
 


### PR DESCRIPTION
Reverts crystal-lang/distribution-scripts#258

This change did not work. For some reason libffi won't build for aarch64. So we must revert this.