### PR TITLE
Remove building custom `libgc` on alpine, use `gc-dev` package

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,12 +14,10 @@ CRYSTAL_TARGZ ?=     ## Which crystal.tar.gz file to install in docker images (u
 DOCKER_TAG ?= $(CRYSTAL_VERSION)## How to tag the docker image (examples: `0.27.2`, `nightly20190307`). `-build` will be appended for build images.
 DOCKER_REPOSITORY ?= crystallang/crystal## Docker hub repository to commit image
 
-GC_VERSION = v8.2.0
-
 OUTPUT_DIR := build
 BUILD_CONTEXT := $(CURDIR)/build-context
 BUILD_ARGS_UBUNTU64 := --build-arg crystal_targz=crystal.tar.gz $(BUILD_CONTEXT)/ubuntu64
-BUILD_ARGS_ALPINE := --build-arg crystal_targz=crystal.tar.gz $(BUILD_CONTEXT)/alpine --build-arg gc_version=$(GC_VERSION)
+BUILD_ARGS_ALPINE := --build-arg crystal_targz=crystal.tar.gz $(BUILD_CONTEXT)/alpine
 DOCKER_TAG_UBUNTU := $(DOCKER_REPOSITORY):$(DOCKER_TAG)
 DOCKER_TAG_ALPINE := $(DOCKER_REPOSITORY):$(DOCKER_TAG)-alpine
 

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -6,26 +6,9 @@ RUN \
     # core dependencies
     gcc gmp-dev libevent-static musl-dev pcre-dev pcre2-dev \
     # stdlib dependencies
-    libxml2-dev libxml2-static openssl-dev openssl-libs-static tzdata yaml-static zlib-static xz-static \
+    gc-dev libxml2-dev libxml2-static openssl-dev openssl-libs-static tzdata yaml-static zlib-static xz-static \
     # dev tools
-    make git \
-    # build libgc dependencies
-    autoconf automake libtool patch
-
-# Build libgc
-ARG gc_version
-
-RUN git clone https://github.com/ivmai/bdwgc \
- && cd bdwgc \
- && git checkout ${gc_version} \
- \
- && ./autogen.sh \
- && ./configure --disable-debug --disable-shared --enable-large-config \
- && make -j$(nproc) CFLAGS=-DNO_GETCONTEXT \
- && make install
-
-# Remove build tools from image now that libgc is built
-RUN apk del -r --purge autoconf automake libtool patch
+    make git
 
 ARG crystal_targz
 COPY ${crystal_targz} /tmp/crystal.tar.gz


### PR DESCRIPTION
I suppose at this point we do not need to build `libgc` ourselves anymore.
We should be able to use the gc package from alpine. It's up to date including the patches that we require for Crystal.

A practical effect of this change is that by default `libgc` will be linked as a dynamic library instead of a static one. This is a subtle change but I don't expect much impact for all practical purposes.
Static linking still works with `--static` of course.
