### PR TITLE
Remove record from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ omnibus/pkg/
 omnibus/.bundle
 omnibus/bin
 omnibus/crystal-darwin-*
-omnibus/shards-darwin-*
 omnibus/vendor
 
 docs/build/


### PR DESCRIPTION
There is no usage of omnibus/shards-darwin-* in the project.
Remove the related record from the `.gitignore`.