### PR TITLE
MacOS target 11.0

### DIFF
--- a/darwin/Makefile
+++ b/darwin/Makefile
@@ -61,7 +61,7 @@ endif
 	mkdir -p $(OUTPUT_DIR) \
 	&& cd ../omnibus \
 	&& if [ "$(FORCE_GIT_TAGGED)" -eq "0" ]; then export CRYSTAL_SRC=$(CURDIR)/tmp/crystal/.git; fi \
-	&& export MACOSX_DEPLOYMENT_TARGET=10.11 \
+	&& export MACOSX_DEPLOYMENT_TARGET=11.0 \
 	&& export SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path) \
 	&& bundle exec omnibus clean crystal shards \
 	&& bundle exec omnibus build crystal \


### PR DESCRIPTION
pcre2 warning message shows, that it could be compiled against 11.0

```
./src/sljit/sljitExecAllocator.c:154:2: warning: 'pthread_jit_write_protect_np' is only available on macOS 11.0 or newer [-Wunguarded-availability-new]
        pthread_jit_write_protect_np(enable_exec);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/pthread.h:588:6: note: 'pthread_jit_write_protect_np' has been marked as being introduced in macOS 11.0 here, but the deployment target is macOS 10.11.0
```

Bump Macos target to 11.0.

PS: It shows on my machine, and does not mean it is the same for other places.