### PR TITLE
Allow to specify custom CRYSTAL_REPO for forks

### DIFF
--- a/darwin/Makefile
+++ b/darwin/Makefile
@@ -3,6 +3,7 @@
 ## Build everything
 ##   $ make
 
+CRYSTAL_REPO ?= https://github.com/crystal-lang/crystal ## Allow to override the official repo with fork or local
 CRYSTAL_VERSION ?=                 ## How the binaries should be branded
 CRYSTAL_SHA1 ?= $(CRYSTAL_VERSION) ## Git tag/branch/sha1 to checkout and build source
 PACKAGE_ITERATION ?= 1
@@ -52,7 +53,7 @@ $(CURDIR)/../omnibus/crystal-darwin-x86_64/embedded/bin/crystal:
 $(OUTPUT_DIR)/$(DARWIN_NAME) $(OUTPUT_DIR)/$(DARWIN_PKG_NAME): ## Build omnibus crystal project
 ifeq ($(FORCE_GIT_TAGGED), 0)
 	rm -Rf $(CURDIR)/tmp && mkdir -p $(CURDIR)/tmp && cd $(CURDIR)/tmp \
-	&& git clone https://github.com/crystal-lang/crystal \
+	&& git clone "$(CRYSTAL_REPO)" \
 	&& cd crystal \
 	&& git checkout $(CRYSTAL_SHA1) \
 	&& git checkout -b $(CRYSTAL_VERSION)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -5,7 +5,8 @@ RUN crystal --version
 
 ARG output_docs_base_name
 ARG crystal_sha1
-RUN git clone https://github.com/crystal-lang/crystal \
+ARG crystal_repo=https://github.com/crystal-lang/crystal
+RUN git clone "${crystal_repo}" \
  && cd crystal \
  && git checkout ${crystal_sha1} \
  \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,4 @@
+CRYSTAL_REPO ?= https://github.com/crystal-lang/crystal ## Allow to override the official repo with fork or local
 CRYSTAL_VERSION ?=                 ## How the binaries should be branded
 CRYSTAL_SHA1 ?= $(CRYSTAL_VERSION) ## Git tag/branch/sha1 to checkout and build source (default: `$(CRYSTAL_VERSION)`)
 CRYSTAL_DOCKER_IMAGE ?= crystallang/crystal:$(CRYSTAL_VERSION)-build ## Which crystal docker build image to use (default: `$(CRYSTAL_VERSION)-build`)
@@ -9,7 +10,7 @@ AWS_CLI = docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -v $$(pw
 S3_ENDPOINT = s3://$(AWS_BUCKET)/api
 AWS_BUCKET = crystal-api
 
-BUILD_ARGS = --build-arg crystal_docker_image=$(CRYSTAL_DOCKER_IMAGE) --build-arg output_docs_base_name=$(OUTPUT_DOCS_BASE_NAME) --build-arg crystal_sha1=$(CRYSTAL_SHA1)
+BUILD_ARGS = --build-arg crystal_docker_image=$(CRYSTAL_DOCKER_IMAGE) --build-arg output_docs_base_name=$(OUTPUT_DOCS_BASE_NAME) --build-arg crystal_repo=$(CRYSTAL_REPO) --build-arg crystal_sha1=$(CRYSTAL_SHA1)
 
 .PHONY: all
 all: $(OUTPUT_DIR)/$(OUTPUT_DOCS_BASE_NAME).tar.gz ## Build docs tarball

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -60,10 +60,11 @@ RUN mkdir -p /tmp/crystal \
   && shards --version
 
 # Build crystal
+ARG crystal_repo=https://github.com/crystal-lang/crystal
 ARG crystal_version
 ARG crystal_sha1
 ARG gnu_target
-RUN git clone https://github.com/crystal-lang/crystal \
+RUN git clone ${crystal_repo} \
  && cd crystal \
  && git checkout ${crystal_sha1} \
  \

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -11,6 +11,7 @@ no_cache ?=    ## Disable the docker build cache
 pull_images ?= ## Always pull docker images to ensure they're up to date
 release ?=     ## Create an optimized build for the final release
 
+CRYSTAL_REPO ?= https://github.com/crystal-lang/crystal ## Allow to override the official repo with fork or local
 CRYSTAL_VERSION ?=                 ## How the binaries should be branded
 CRYSTAL_SHA1 ?= $(CRYSTAL_VERSION) ## Git tag/branch/sha1 to checkout and build source
 PACKAGE_ITERATION ?= 1
@@ -32,6 +33,7 @@ DOCKER_BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )
 
 BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
                     $(if $(release),--build-arg release=true) \
+                    --build-arg crystal_repo=$(CRYSTAL_REPO) \
                     --build-arg crystal_version=$(CRYSTAL_VERSION) \
                     --build-arg crystal_sha1=$(CRYSTAL_SHA1) \
                     --build-arg shards_version=$(SHARDS_VERSION) \


### PR DESCRIPTION
When constructing a Crystal project, the common practice involves either downloading or cloning the official Git repository for most dependencies. 
It is essential to ensure the ability to test changes against forked repositories. 
I recommend extracting static values into variables for improved flexibility. 
This suggestion involves introducing a `CRYSTAL_REPO` variable with a default value pointing to the official repository.