### PR TITLE
Install `libgc-dev` in ubuntu Dockerfile

### DIFF
--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y tzdata gcc pkg-config libssl-dev libxml2-dev libyaml-dev libgmp-dev git make \
-                     libpcre3-dev libpcre2-dev libevent-dev libz-dev && \
+                     libpcre3-dev libpcre2-dev libevent-dev libz-dev libgc-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG crystal_targz


### PR DESCRIPTION
This makes sure the development package is installed, which includes the pkg-config file (see https://github.com/crystal-lang/crystal/issues/14195#issuecomment-1884786488).

Also, we should stop building our own libgc, which will require installing the library explicitly (#285).