### PR TITLE
Fix installer detect Debian version

### DIFF
--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -70,7 +70,7 @@ _discover_distro_repo() {
 
   case "$ID" in
     debian)
-      if [[ -z "${VERSION_ID:+}" ]]; then
+      if [[ -z "${VERSION_ID:-}" ]]; then
         VERSION_ID="Unstable"
       elif [[ "$VERSION_ID" == "9" ]]; then
         VERSION_ID="$VERSION_ID.0"


### PR DESCRIPTION
Fixes a bug in the installer script which lead to choosing `Debian_Unstable` for *every* debian version.

See https://github.com/crystal-lang/distribution-scripts/issues/264#issuecomment-1894793397