### PR TITLE
Fix macos triple

### DIFF
--- a/omnibus/config/software/crystal.rb
+++ b/omnibus/config/software/crystal.rb
@@ -68,14 +68,12 @@ build do
   mkdir ".build"
   copy "#{output_bin}_x86_64", ".build/crystal"
 
-  # Compile for ARM64. Apple's clang only understands arm64, LLVM uses aarch64,
-  # so we need to sub out aarch64 in our calls to Apple tools
-  env["CXXFLAGS"] << " -target arm64-apple-darwin"
   make "deps", env: env
 
-  make "crystal stats=true release=true target=aarch64-apple-darwin FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_TARGET=aarch64-apple-darwin CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
+  crtarget = "arm64-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
+  make "crystal stats=true release=true target=#{crtarget} FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_TARGET=#{crtarget} CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
 
-  command "clang #{output_path}/crystal.o -o #{output_bin}_arm64 -target arm64-apple-darwin src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags 2>/dev/null` -lstdc++ -lpcre2-8 -lgc -lpthread -levent -liconv -ldl -v", env: env
+  command "clang #{output_path}/crystal.o -o #{output_bin}_arm64 -target #{crtarget} src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags 2>/dev/null` -lstdc++ -lpcre2-8 -lgc -lpthread -levent -liconv -ldl -v", env: env
   delete "#{output_path}/crystal.o"
 
   # Lipo them up

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -96,9 +96,10 @@ build do
   make "clean", env: env
 
   # Build for ARM64
-  crflags += " --cross-compile --target aarch64-apple-darwin"
+  crtarget = "arm64-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
+  crflags += " --cross-compile --target #{crtarget}"
   make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
-  command "clang bin/shards.o -o bin/shards_arm64 -target arm64-apple-darwin -L#{install_dir}/embedded/lib -lyaml -lpcre2-8 -lgc -lpthread -levent -liconv -ldl", env: env
+  command "clang bin/shards.o -o bin/shards_arm64 -target #{crtarget} -L#{install_dir}/embedded/lib -lyaml -lpcre2-8 -lgc -lpthread -levent -liconv -ldl", env: env
 
   # Lipo them up
   command "lipo -create -output bin/shards bin/shards_x86_64 bin/shards_arm64"


### PR DESCRIPTION
I've been investigating [this issue](https://github.com/crystal-lang/crystal/issues/13846) and it's related to the default target triple produced by Crystal during compilation. It seems like in order to fix a [bug](https://github.com/crystal-lang/crystal/issues/1402) back in 2015, we stripped the minimum deployment target from the target triple in this [commit](https://github.com/crystal-lang/crystal/commit/5bbf4d193aba0663b70ee3fbf750ac86b9e966b0). With the release of Xcode 15, a [new linker was introduced](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking) and with it came these warning messages. It appears that the new linker is stricter in which target triples it considers valid. Specifically, it looks like the minimum deployment target is required. E.g., `aarch64-apple-darwin23.3.0` is valid, while `aarch64-apple-darwin` is not.

We still need to handle the issue of normalization that's [happening here](https://github.com/crystal-lang/crystal/blob/1abc04ed04f4dcf0a2ed8b1e825bf7a0821ebab2/src/llvm.cr#L91-L109), probably by not normalizing the macOS target triple at all and I'll do that in a follow up pull request.