### PR TITLE
Drop building libgc on Linux

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,23 +1,3 @@
-FROM debian:11 AS debian
-
-RUN apt-get update \
- && apt-get install -y build-essential libevent-dev libpcre2-dev automake libtool pkg-config git curl llvm-13 clang-13 \
- && (pkg-config || true)
-
-ARG release
-ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
-ENV CC="clang-13"
-
-# Build libgc
-ARG gc_version
-
-RUN git clone https://github.com/ivmai/bdwgc \
- && cd bdwgc \
- && git checkout ${gc_version} \
- && ./autogen.sh \
- && ./configure --disable-debug --disable-shared --enable-large-config \
- && make -j$(nproc)
-
 FROM alpine:3.17
 
 # Install dependencies
@@ -85,15 +65,10 @@ RUN git clone https://github.com/crystal-lang/shards \
  \
  && ([ "$(ldd bin/shards 2>&1 | wc -l)" -eq "1" ] || { echo 'shards is not statically linked'; ldd bin/shards; exit 1; })
 
-COPY --from=debian /bdwgc/.libs/libgc.a /libgc-debian.a
-
 ARG package_iteration
 
 RUN \
- # Copy libgc.a to /lib/crystal/
  mkdir -p /output/lib/crystal/ \
- && cp /libgc-debian.a /output/lib/crystal/libgc.a \
- \
  # Install crystal
  && make -C /crystal install DESTDIR=/output PREFIX= \
  \


### PR DESCRIPTION
We don't need to ship a specially-built version of libgc anymore. This patch drops it from the regular package and moves the build instructions to the bundled package which also includes other necessary libraries.
For this reason we're still keeping `CRYSTAL_CONFIG_LIBRARY_PATH` so that it's still possible to add bundled libraries to that path.

Resolves part of #285