### PR TITLE
Update LLVM 18

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -26,6 +26,6 @@ FROM runtime as build
 
 RUN \
   apk add --update --no-cache --force-overwrite \
-    llvm15-dev llvm15-static g++ libffi-dev
+    llvm18-dev llvm18-static g++ libffi-dev
 
 CMD ["/bin/sh"]

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -23,7 +23,7 @@ FROM runtime as build
 
 RUN \
   apt-get update && \
-  apt-get install -y build-essential llvm-15 lld-15 libedit-dev gdb libffi-dev && \
+  apt-get install -y build-essential llvm-18 lld-18 libedit-dev gdb libffi-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN ln -sf /usr/bin/ld.lld-15 /usr/bin/ld.lld

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:3.20
 # Install dependencies
 RUN apk add --no-cache \
       # Statically-compiled llvm
-      llvm15-dev llvm15-static \
+      llvm18-dev llvm18-static \
       # Static stdlib dependencies
       gc-dev zlib-static yaml-static libxml2-static pcre2-dev libevent-static zstd-static \
       # Static compiler dependencies
@@ -40,7 +40,7 @@ ENV CFLAGS="-fPIC -pipe ${release:+-O2}"
 # This particularly affects libgc which was bundled upto Crystal 1.12
 ENV CRYSTAL_LIBRARY_PATH=""
 
-RUN llvm15-config --version
+RUN llvm18-config --version
 
 ARG previous_crystal_release
 ADD ${previous_crystal_release} /tmp/crystal.tar.gz


### PR DESCRIPTION
Updates LLVM to version 18 (from 15) in the build environment as well as the docker images for alpine and ubuntu.