### PR TITLE
Update `omnibus` build instructions for aarch64 runner

### DIFF
--- a/darwin/Makefile
+++ b/darwin/Makefile
@@ -66,8 +66,8 @@ endif
 	&& export SDKROOT=$(shell xcrun --sdk macosx --show-sdk-path) \
 	&& bundle exec omnibus clean crystal shards \
 	&& bundle exec omnibus build crystal \
-	&& cp ./pkg/$(DARWIN_NAME) $(CURDIR)/$(OUTPUT_DIR)/$(subst x86_64,universal,$(DARWIN_NAME)) \
-	&& cp ./pkg/$(DARWIN_PKG_NAME) $(CURDIR)/$(OUTPUT_DIR)/$(subst x86_64,universal,$(DARWIN_PKG_NAME))
+	&& cp ./pkg/$(DARWIN_NAME) $(CURDIR)/$(OUTPUT_DIR)/$(subst x86_64,universal,$(subst arm64,universal,$(DARWIN_NAME))) \
+	&& cp ./pkg/$(DARWIN_PKG_NAME) $(CURDIR)/$(OUTPUT_DIR)/$(subst x86_64,universal,$(subst arm64,universal,$(DARWIN_PKG_NAME)))
 
 .PHONY: clean
 clean: ## Clean up build directory

--- a/omnibus/config/software/crystal.rb
+++ b/omnibus/config/software/crystal.rb
@@ -55,7 +55,7 @@ build do
 
   crflags = "--no-debug"
 
-  copy "#{Dir.pwd}/crystal-#{ohai['os']}-#{ohai['kernel']['machine']}/embedded/bin/crystal", ".build/crystal"
+  copy "#{Dir.pwd}/crystal-#{ohai['os']}-x86_64/embedded/bin/crystal", ".build/crystal"
 
   # Compile for Intel
   command "make crystal stats=true release=true FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env

--- a/omnibus/config/software/crystal.rb
+++ b/omnibus/config/software/crystal.rb
@@ -57,23 +57,27 @@ build do
 
   copy "#{Dir.pwd}/crystal-#{ohai['os']}-x86_64/embedded/bin/crystal", ".build/crystal"
 
-  # Compile for Intel
-  command "make crystal stats=true release=true FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
-  move output_bin, "#{output_bin}_x86_64"
+  # Compile native
+  native_target = "#{ohai['kernel']['machine']}-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
+  make "crystal stats=true release=true FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_TARGET=#{native_target} CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
+  move output_bin, "#{output_bin}_#{ohai['kernel']['machine']}"
 
   # Clean up
   make "clean_cache clean", env: env
 
-  # Restore x86_64 compiler w/ cross-compile support
+  # Restore native compiler w/ cross-compile support
   mkdir ".build"
-  copy "#{output_bin}_x86_64", ".build/crystal"
+  copy "#{output_bin}_#{ohai['kernel']['machine']}", ".build/crystal"
+
+  # Cross-compile for other arch
 
   make "deps", env: env
 
-  crtarget = "arm64-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
-  make "crystal stats=true release=true target=#{crtarget} FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_TARGET=#{crtarget} CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
+  other_machine = ohai['kernel']['machine'] == "x86_64" ? "arm64" : "x86_64"
+  other_target = "#{other_machine}-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
+  make "crystal stats=true release=true target=#{other_target} FLAGS=\"#{crflags}\" CRYSTAL_CONFIG_TARGET=#{other_target} CRYSTAL_CONFIG_LIBRARY_PATH= O=#{output_path}", env: env
 
-  command "clang #{output_path}/crystal.o -o #{output_bin}_arm64 -target #{crtarget} src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags 2>/dev/null` -lstdc++ -lpcre2-8 -lgc -lpthread -levent -liconv -ldl -v", env: env
+  command "clang #{output_path}/crystal.o -o #{output_bin}_#{other_machine} -target #{other_target} src/llvm/ext/llvm_ext.o `llvm-config --libs --system-libs --ldflags 2>/dev/null` -lstdc++ -lpcre2-8 -lgc -lpthread -levent -liconv -ldl -v", env: env
   delete "#{output_path}/crystal.o"
 
   # Lipo them up

--- a/omnibus/config/software/llvm_bin.rb
+++ b/omnibus/config/software/llvm_bin.rb
@@ -18,7 +18,7 @@ else
   raise "llvm_bin not supported"
 end
 
-source url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-#{version}-#{ohai['os']}-#{ohai['kernel']['machine']}.tar.gz",
+source url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-#{version}-#{ohai['os']}-x86_64.tar.gz",
        md5: source_md5
 
 relative_path "llvm-#{version}"

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -88,18 +88,19 @@ env["CPPFLAGS"] = env["CPPFLAGS"].gsub("-arch arm64 -arch x86_64", "")
 build do
   crflags = "--no-debug --release"
 
-  # Build for Intel
+  # Build native
   make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
-  move "bin/shards", "bin/shards_x86_64"
+  move "bin/shards", "bin/shards_#{ohai['kernel']['machine']}"
 
   # Clean
   make "clean", env: env
 
-  # Build for ARM64
-  crtarget = "arm64-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
-  crflags += " --cross-compile --target #{crtarget}"
+  # Cross-compile for other arch
+  other_machine = ohai['kernel']['machine'] == "x86_64" ? "arm64" : "x86_64"
+  other_target = "#{other_machine}-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
+  crflags += " --cross-compile --target #{other_target}"
   make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
-  command "clang bin/shards.o -o bin/shards_arm64 -target #{crtarget} -L#{install_dir}/embedded/lib -lyaml -lpcre2-8 -lgc -lpthread -levent -liconv -ldl", env: env
+  command "clang bin/shards.o -o bin/shards_#{other_machine} -target #{other_target} -L#{install_dir}/embedded/lib -lyaml -lpcre2-8 -lgc -lpthread -levent -liconv -ldl", env: env
 
   # Lipo them up
   command "lipo -create -output bin/shards bin/shards_x86_64 bin/shards_arm64"


### PR DESCRIPTION
The updated recipes should build on both, x86_64 and arm64 machines.
I have not tested them on x86_64 though.
To fix CI, only arm64 matters.

CI workflow run: https://app.circleci.com/pipelines/github/crystal-lang/crystal/15386/workflows/76ecd816-2187-4eed-aef2-a4959240f1b2/jobs/84572

Resolves #318