### PR TITLE
Add installer test for Amazon Linux 2023

### DIFF
--- a/packages/test-install-on-docker.sh
+++ b/packages/test-install-on-docker.sh
@@ -4,4 +4,4 @@ set -eu
 
 docker_image="${1}"
 
-docker run --pull=always -e OBS_PROJECT="${OBS_PROJECT:-}" -e CRYSTAL_VERSION="${CRYSTAL_VERSION:-}" --rm -v $(pwd)/scripts:/scripts -v $(pwd)/support:/support $docker_image /bin/sh -c "/support/test-install.sh ${@:2}"
+docker run --pull=always -e OBS_PROJECT="${OBS_PROJECT:-}" -e CRYSTAL_VERSION="${CRYSTAL_VERSION:-}" --rm -v $(pwd)/scripts:/scripts -v $(pwd)/support:/support -w / --entrypoint /bin/sh $docker_image -c "/support/test-install.sh ${@:2}"

--- a/packages/test/amazon.bats
+++ b/packages/test/amazon.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "Amazon Linux 2023" {
+  ./test-install-on-docker.sh amazonlinux:2023
+}

--- a/packages/test/amazon.bats
+++ b/packages/test/amazon.bats
@@ -3,3 +3,8 @@
 @test "Amazon Linux 2023" {
   ./test-install-on-docker.sh amazonlinux:2023
 }
+
+# This image is stripped down and only comes with microdnf
+@test "Amazon Linux 2023 Lambda" {
+  ./test-install-on-docker.sh public.ecr.aws/lambda/provided:al2023
+}


### PR DESCRIPTION
Amazon Linux is a popular Linux distribution for which we don't provide explicit packages, but it can use the fallback packages for Fedora. Adding this test ensures we'll notice if anything breaks there.

