### PR TITLE
Fix update bin directory in linux build instructions

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -43,8 +43,7 @@ RUN llvm18-config --version
 
 ARG previous_crystal_release
 ADD ${previous_crystal_release} /tmp/crystal.tar.gz
-# TODO: Update path to new install directory /tmp/crystal/bin after migration period
-ENV PATH=${PATH}:/tmp/crystal/lib/crystal/bin/
+ENV PATH=${PATH}:/tmp/crystal/bin/
 RUN mkdir -p /tmp/crystal \
   && tar xz -f /tmp/crystal.tar.gz -C /tmp/crystal --strip-component=1 \
   && crystal --version \


### PR DESCRIPTION
Nightly builds are broken because the linux build instructions expect the previous compiler in an old path which was removed in #302. This patch updates to the new path which has been available for years.