### PR TITLE
Drop package install test for CentOS stream

### DIFF
--- a/packages/test/centos.bats
+++ b/packages/test/centos.bats
@@ -1,5 +1,0 @@
-#!/usr/bin/env bats
-
-@test "CentOS 8 Stream" {
-  ./test-install-on-docker.sh quay.io/centos/centos:stream8
-}


### PR DESCRIPTION
CentOS 8 Stream is EOL and the test fails because mirrors are down