### PR TITLE
Add Dockerfiles for build images based on 84codes base images

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -73,6 +73,12 @@ $(OUTPUT_DIR)/docker-$(CRYSTAL_VERSION)-alpine-build.tar.gz: $(BUILD_CONTEXT)/al
 	docker build -t $(DOCKER_TAG_ALPINE)-build --target build $(BUILD_ARGS_ALPINE)
 	docker save $(DOCKER_TAG_ALPINE)-build | gzip > $@
 
+alpine-84codes: ## Build and push docker build images based on the base images from 84codes
+	docker buildx build --build-arg crystal_version=$(CRYSTAL_VERSION) -f alpine-84codes.Dockerfile --platform linux/amd64,linux/arm64 --tag crystallang/crystal:$(CRYSTAL_VERSION)-alpine-84codes-build --push .
+
+ubuntu-84codes: ## Build and push docker build images based on the base images from 84codes
+	docker buildx build --build-arg crystal_version=$(CRYSTAL_VERSION) -f ubuntu-84codes.Dockerfile --platform linux/amd64,linux/arm64 --tag crystallang/crystal:$(CRYSTAL_VERSION)-ubuntu-84codes-build --push .
+
 .PHONY: clean
 clean: ## Clean up build and output directories
 	rm -Rf $(OUTPUT_DIR)

--- a/docker/alpine-84codes.Dockerfile
+++ b/docker/alpine-84codes.Dockerfile
@@ -1,0 +1,9 @@
+ARG crystal_version
+FROM 84codes/crystal:${crystal_version}-alpine AS build
+
+RUN \
+  apk add --update --no-cache --force-overwrite \
+    llvm18-dev llvm18-static g++ libffi-dev
+
+ENTRYPOINT []
+CMD ["/bin/sh"]

--- a/docker/ubuntu-84codes.Dockerfile
+++ b/docker/ubuntu-84codes.Dockerfile
@@ -1,0 +1,12 @@
+ARG crystal_version
+FROM 84codes/crystal:${crystal_version}-ubuntu-24.04 AS build
+
+RUN \
+  apt-get update && \
+  apt-get install -y build-essential llvm-18 lld-18 libedit-dev gdb libffi-dev && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN ln -sf /usr/bin/ld.lld-18 /usr/bin/ld.lld
+
+ENTRYPOINT []
+CMD ["/bin/sh"]


### PR DESCRIPTION
These docker files are based on the [images from 84codes](https://hub.docker.com/r/84codes/crystal) and add the specific dependencies required for building the compiler (particularly `libllvm`, `libffi`) and are copied from the existing `alpine.Dockerfile` and `ubuntu.Dockerfile`.

This results in up-to-date build images for `linux/arm64` which we're using for Aarch64 CI in https://github.com/crystal-lang/crystal/pull/15007