### PR TITLE
Use `--progress=plain` docker arg for full log output

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -94,4 +94,4 @@ RUN \
  # Create tarball
  && mv /output /crystal-${crystal_version}-${package_iteration} \
  && mkdir /output \
- && tar -cvf /output/crystal-${crystal_version}-${package_iteration}.tar /crystal-${crystal_version}-${package_iteration}
+ && tar -cf /output/crystal-${crystal_version}-${package_iteration}.tar /crystal-${crystal_version}-${package_iteration}

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -29,7 +29,7 @@ LIBEVENT_VERSION = release-2.1.12-stable
 OUTPUT_DIR = build
 OUTPUT_BASENAME64 = $(OUTPUT_DIR)/crystal-$(CRYSTAL_VERSION)-$(PACKAGE_ITERATION)-linux-x86_64
 
-DOCKER_BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull )
+DOCKER_BUILD_ARGS = $(if $(no_cache),--no-cache )$(if $(pull_images),--pull ) --progress=plain
 
 BUILD_ARGS_COMMON = $(DOCKER_BUILD_ARGS) \
                     $(if $(release),--build-arg release=true) \

--- a/linux/bundled.dockerfile
+++ b/linux/bundled.dockerfile
@@ -39,4 +39,4 @@ COPY --from=libevent libevent/.libs/libevent.a libevent/.libs/libevent_pthreads.
 # Create tarball
 RUN mv /output /crystal-${crystal_version}-${package_iteration} \
  && mkdir /output \
- && tar -cvf /output/bundled-libs.tar /crystal-${crystal_version}-${package_iteration}
+ && tar -cf /output/bundled-libs.tar /crystal-${crystal_version}-${package_iteration}


### PR DESCRIPTION
Docker by default groups log output per step and reduces it (basically just prints the full output if the step failed). This patch adds `--progress=plain` to enable showing the entire log output.

To reduce the overall amount of log output we remove the verbose flag from tar commands. It's not really useful to list all the hundreds of files that get put into the tarball.