### PR TITLE
Fix touch `shard.lock` after checkout

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -73,8 +73,7 @@ RUN git clone https://github.com/crystal-lang/shards \
          FLAGS="--stats --target ${musl_target} --static ${release:+--release}" \
  \
  && bin/shards --version \
- && ( (readelf --program-headers bin/shards | grep -q "Elf file type is EXEC") || { echo 'shards is not statically linked'; exit 1; }) \
- && readelf --program-headers bin/shards
+ && ( (readelf --program-headers bin/shards | grep -q "Elf file type is EXEC") || { echo 'shards is not statically linked'; exit 1; })
 
 COPY --from=bdwgc /bdwgc/.libs/libgc.a /libgc-debian.a
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -69,6 +69,9 @@ ARG musl_target
 RUN git clone https://github.com/crystal-lang/shards \
  && cd shards \
  && git checkout ${shards_version} \
+ # FIXME: This is a workaround for shards' Makefile not touching `shard.lock`
+ # when SHARDS=false
+ && touch shard.lock \
  && make SHARDS=false CRYSTAL=/crystal/bin/crystal \
          FLAGS="--stats --target ${musl_target} --static ${release:+--release}" \
  \


### PR DESCRIPTION
This is a workaround for https://github.com/crystal-lang/shards/pull/667

Resolves https://github.com/crystal-lang/distribution-scripts/issues/330