### PR TITLE
Install asciidoctor in build environment

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache \
       # Static compiler dependencies
       libffi-dev \
       # Build tools
-      git gcc g++ make automake libtool autoconf bash coreutils curl
+      git gcc g++ make automake libtool autoconf bash coreutils curl asciidoctor
 
 ARG release
 ENV CFLAGS="-fPIC -pipe ${release:+-O2}"


### PR DESCRIPTION
This is required for building manpages from asciidoc.

The darwin package currently doesn't ship crystal or shards manpages, so we don't need this there (yet).

Related: https://github.com/crystal-lang/crystal/issues/15536