### PR TITLE
[CI] Update xcode to 26.0.1 on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   omnibus_osx_llvm:
     macos:
-      xcode: 15.3.0
+      xcode: 26.0.1
     environment:
       LLVM_VERSION: 15.0.7
       MACOSX_DEPLOYMENT_TARGET: 10.11


### PR DESCRIPTION
xcode 15.3 is deprecated: https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

I'm taking the chance to upgrade to the newest version available.

Related to https://github.com/crystal-lang/crystal/pull/16201