### PR TITLE
Drop shards bootstrap

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -70,10 +70,7 @@ ARG musl_target
 RUN git clone https://github.com/crystal-lang/shards \
  && cd shards \
  && git checkout ${shards_version} \
- # FIXME: This is a workaround for shards' Makefile not touching `shard.lock`
- # when SHARDS=false
- && touch shard.lock \
- && make SHARDS=false CRYSTAL=/crystal/bin/crystal \
+ && make CRYSTAL=/crystal/bin/crystal \
          FLAGS="--stats --target ${musl_target} --static ${release:+--release}" \
  \
  && bin/shards --version \

--- a/omnibus/config/software/shards.rb
+++ b/omnibus/config/software/shards.rb
@@ -97,7 +97,7 @@ build do
   crflags = "--no-debug --release"
 
   # Build native
-  make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
+  make "bin/shards CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
   move "bin/shards", "bin/shards_#{ohai['kernel']['machine']}"
 
   # Clean
@@ -107,7 +107,7 @@ build do
   other_machine = ohai['kernel']['machine'] == "x86_64" ? "arm64" : "x86_64"
   other_target = "#{other_machine}-apple-macosx#{ENV["MACOSX_DEPLOYMENT_TARGET"]}"
   crflags += " --cross-compile --target #{other_target}"
-  make "bin/shards SHARDS=false CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
+  make "bin/shards CRYSTAL=#{install_dir}/bin/crystal FLAGS='#{crflags}'", env: env
   command "clang bin/shards.o -o bin/shards_#{other_machine} -target #{other_target} -L#{install_dir}/embedded/lib -lyaml -lpcre2-8 -lgc -lpthread -levent -liconv -ldl", env: env
 
   # Lipo them up


### PR DESCRIPTION
The `lib/` directory is vendored into the repository and there's no need for checking out external sources anymore, so we can skip this disablement.