### PR TITLE
Snap: core22 + arm64 build target + make push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ docs/build/
 
 darwin/build/
 
-snapcraft/snap/snapcraft.yaml
+snapcraft/snapcraft.yaml
 snapcraft/*.snap
 snapcraft/build/

--- a/snapcraft/Makefile
+++ b/snapcraft/Makefile
@@ -1,15 +1,22 @@
-OUTPUT_DIR = build
+CRYSTAL_TARBALL =
+ARCH =
+GRADE =
+CHANNEL =
 
 .PHONY: all
-all: snap/snapcraft.yaml
-	mkdir -p $(OUTPUT_DIR)
-	snapcraft
-	mv *.snap $(OUTPUT_DIR)
+all: snapcraft.yaml
+	snapcraft pack --build-for=$(ARCH)
 
-.PHONY: snap/snapcraft.yaml
-snap/snapcraft.yaml:
-	sed 's/$${CRYSTAL_RELEASE_LINUX64_TARGZ}/$(subst /,\/,$(CRYSTAL_RELEASE_LINUX64_TARGZ))/; s/$${SNAP_GRADE}/$(SNAP_GRADE)/' snap/local/snapcraft.yaml.tpl > $@
+.PHONY: snapcraft.yaml
+snapcraft.yaml:
+	sed 's/$${CRYSTAL_TARBALL}/$(subst /,\/,$(CRYSTAL_TARBALL))/; s/$${SNAP_GRADE}/$(GRADE)/' local/snapcraft.yaml.tpl > $@
+
+.PHONY: push
+push:
+	for SNAPFILE in *.snap; do\
+		sudo -E snapcraft upload --quiet --release=$(CHANNEL) $$SNAPFILE;\
+	done
 
 clean:
-	rm snap/snapcraft.yaml
-	rm -Rf $(OUTPUT_DIR)
+	snapcraft clean
+	rm -f snapcraft.yaml *.snap

--- a/snapcraft/README.md
+++ b/snapcraft/README.md
@@ -1,20 +1,29 @@
 # snap for Crystal
 
-https://snapcraft.io/crystal
+<https://snapcraft.io/crystal>
 
 ## Dependencies
 
 - [`snapcraft`](https://docs.snapcraft.io/snapcraft-overview)
 
-## Build the snap
+For example on Ubuntu:
 
-Define the configuration variables and use `make` to expand the `./snap/local/snapcraft.yaml.tpl`.
-
-```sh
-$ SNAP_GRADE=devel CRYSTAL_RELEASE_LINUX64_TARGZ="https://github.com/crystal-lang/crystal/releases/download/0.29.0/crystal-0.29.0-1-linux-x86_64.tar.gz" make
+```console
+$ sudo apt-get install snapd
+$ snap install snapcraft --classic
 ```
 
-## Snap channels usage
+## Build
+
+Define the configuration variables and use `make` to expand the `./local/snapcraft.yaml.tpl`.
+
+```console
+$ export SNAPCRAFT_BUILD_ENVIRONMENT=host
+$ make GRADE=devel ARCH=amd64 CRYSTAL_TARBALL=../linux/build/crystal-$(CRYSTAL_VERSION)-1-linux-x86_64.tar.gz
+$ make GRADE=devel ARCH=arm64 CRYSTAL_TARBALL=../linux/build/crystal-$(CRYSTAL_VERSION)-1-linux-aarch64.tar.gz
+```
+
+## Channels
 
 | Build             | Channel                    | Version   | Comments                                             |
 |-------------------|----------------------------|-----------|------------------------------------------------------|
@@ -24,15 +33,16 @@ $ SNAP_GRADE=devel CRYSTAL_RELEASE_LINUX64_TARGZ="https://github.com/crystal-lan
 
 ### Configuration
 
-* `CRYSTAL_RELEASE_LINUX64_TARGZ`: Url to crystal-{version}-{package}-linux-x86_64.tar.gz
-* `SNAP_GRADE`: Snap grande usually `devel` for nightlies and `stable` for tagged releases
+* `CRYSTAL_TARBALL`: path to `crystal-{version}-{package}-linux-{arch}.tar.gz`
+* `ARCH`: the architecture to build (`amd64` or `arm64`)
+* `GRADE`: Snap grade (`devel` for nightlies, `stable` for tagged releases)
 
 ## Install the snap
 
 1. [Have snapd installed](https://snapcraft.io/docs/core/install)
 
 2.
-    ```
+    ```console
     $ sudo snap install crystal --classic
     ```
 

--- a/snapcraft/local/snapcraft.yaml.tpl
+++ b/snapcraft/local/snapcraft.yaml.tpl
@@ -1,5 +1,5 @@
 name: crystal
-base: core
+base: core22
 summary: A language for humans and computers
 description: |
   * Have a syntax similar to Ruby (but compatibility with it is not a goal)
@@ -7,6 +7,12 @@ description: |
   * Be able to call C code by writing bindings to it in Crystal.
   * Have compile-time evaluation and generation of code, to avoid boilerplate code. Compile to efficient native code.
 adopt-info: crystal
+
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [amd64, arm64]
+    build-for: [arm64]
 
 grade: ${SNAP_GRADE}
 confinement: classic
@@ -24,10 +30,10 @@ apps:
 parts:
   crystal:
     plugin: dump
-    source: ${CRYSTAL_RELEASE_LINUX64_TARGZ}
+    source: ${CRYSTAL_TARBALL}
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version "$(cat $SNAPCRAFT_PART_SRC/share/crystal/src/VERSION | head -n 1)"
+      craftctl default
+      craftctl set version="$(cat $CRAFT_PART_SRC/share/crystal/src/VERSION | head -n 1)"
 
   snap-wrapper:
     plugin: dump


### PR DESCRIPTION
Upgrades to `core22` (Ubuntu 22.04) from `core`(16) that didn't support architectures in addition to be very outdated.

Declares the `arm64` target in addition to the `amd64` target. Both can be built on either target, but because of the target specific tarball, they must each be built separately.

Adds the `make push` target as a convenient helper.

The `Makefile` now takes explicit variables instead of implicit environment variables:

- `ARCH`: any architecture supported by crystal & snap (`amd64` and `arm64`).
- `GRADE`: the snap grade (`devel` or `stable`).
- `CHANNEL`: the snap channel (`edge` or `edge/<branch>`).

For example:

```console
$ make ARCH=amd64 CRYSTAL_TARBALL=/tmp/workspace/build/crystal-$(CRYSTAL_VERSION)-1-linux-x86_64.tar.gz GRADE=$SNAP_GRADE
$ make ARCH=arm64 CRYSTAL_TARBALL=/tmp/workspace/build/crystal-$(CRYSTAL_VERSION)-1-linux-aarch64.tar.gz GRADE=$SNAP_GRADE
$ make push CHANNEL=$SNAP_CHANNEL
```