### PR TITLE
Docker: use buildx to tag the latest images after release

### DIFF
--- a/docker/apply-latest-tags.sh
+++ b/docker/apply-latest-tags.sh
@@ -15,14 +15,10 @@ apply_tag() {
 
   echo "Publishing ${base_tag} as ${new_tag}"
 
-  docker tag "${base_tag}" "${new_tag}"
-  docker push "${new_tag}"
+  docker buildx imagetools create {$base_tag} --tag ${new_tag}
 }
 
 version=$1
-
-docker pull "crystallang/crystal:${version}"
-docker pull "crystallang/crystal:${version}-alpine"
 
 # Tag latest
 apply_tag "crystallang/crystal:${version}"        "crystallang/crystal:latest"


### PR DESCRIPTION
It spares downloading the image layers (only the manifest) and because it acts on the manifest, it doesn't lose the multiarch images when creating the tag alias.