### PR TITLE
Add `gmp` static package

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -5,7 +5,7 @@ ARG llvm_version=20
 RUN \
   apk add --update --no-cache --force-overwrite \
     # core dependencies
-    gcc gmp-dev musl-dev pcre-dev pcre2-dev pcre2-static \
+    gcc gmp-dev gmp-static musl-dev pcre-dev pcre2-dev pcre2-static \
     # stdlib dependencies
     gc-dev gc-static libxml2-dev libxml2-static openssl-dev openssl-libs-static tzdata yaml-static zlib-static xz-static \
     # dev tools


### PR DESCRIPTION
User on [Discord](https://discord.com/channels/591460182777790474/591597160492171264/1477065132642144399) was having trouble building using the Alpine image due to:

```txt
#13 298.2 E: Error target ess_evaluation_site failed to compile:
#13 298.2 /usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lgmp
```

It seemingly was missing the static `gmp` package