### PR TITLE
Use `--base-path` when generating API docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -5,12 +5,13 @@ RUN crystal --version
 
 ARG output_docs_base_name
 ARG crystal_sha1
+ARG crystal_version
 ARG crystal_repo=https://github.com/crystal-lang/crystal
 RUN git clone "${crystal_repo}" \
  && cd crystal \
  && git checkout ${crystal_sha1} \
  \
- && make docs DOCS_OPTIONS='--json-config-url=/api/versions.json  --canonical-base-url="https://crystal-lang.org/api/latest/"'\
+ && make docs DOCS_OPTIONS='--json-config-url=/api/versions.json  --canonical-base-url="https://crystal-lang.org/api/latest/" --base-path="/api/${crystal_version}"'\
  && git describe --tags --long --always 2>/dev/null > ./docs/revision.txt \
  && mv ./docs ./${output_docs_base_name} \
  \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ AWS_CLI = docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -v $$(pw
 S3_ENDPOINT = s3://$(AWS_BUCKET)/api
 AWS_BUCKET = crystal-api
 
-BUILD_ARGS = --build-arg crystal_docker_image=$(CRYSTAL_DOCKER_IMAGE) --build-arg output_docs_base_name=$(OUTPUT_DOCS_BASE_NAME) --build-arg crystal_repo=$(CRYSTAL_REPO) --build-arg crystal_sha1=$(CRYSTAL_SHA1)
+BUILD_ARGS = --build-arg crystal_docker_image=$(CRYSTAL_DOCKER_IMAGE) --build-arg output_docs_base_name=$(OUTPUT_DOCS_BASE_NAME) --build-arg crystal_repo=$(CRYSTAL_REPO) --build-arg crystal_sha1=$(CRYSTAL_SHA1) --build-arg crystal_version=$(CRYSTAL_VERSION)
 
 .PHONY: all
 all: $(OUTPUT_DIR)/$(OUTPUT_DOCS_BASE_NAME).tar.gz ## Build docs tarball


### PR DESCRIPTION
This option is available since Crystal 1.20 (https://github.com/crystal-lang/crystal/pull/16091)