### PR TITLE
Fix: debian package changelog

### DIFF
--- a/packages/obs-new-minor.sh
+++ b/packages/obs-new-minor.sh
@@ -46,9 +46,9 @@ osc mv "${OLD_PACKAGE}-docs.dsc" "${PACKAGE}-docs.dsc"
 cat <<EOF > debian.changelog
 ${PACKAGE} (${VERSION}-1) stable; urgency=low
 
-* Create package for ${BASE_PACKAGE} ${VERSION}
+  * Create package for ${BASE_PACKAGE} ${VERSION}
 
--- Crystal Team <crystal@manas.tech>  $(LC_ALL=en_US date --utc +'%a, %-d %b %Y %T +0000')
+  -- Crystal Team <crystal@manas.tech>  $(LC_ALL=en_US date --utc +'%a, %-d %b %Y %T +0000')
 EOF
 echo > *.changes
 

--- a/packages/obs-new-minor.sh
+++ b/packages/obs-new-minor.sh
@@ -48,7 +48,7 @@ ${PACKAGE} (${VERSION}-1) stable; urgency=low
 
 * Create package for ${BASE_PACKAGE} ${VERSION}
 
--- Crystal Team <crystal@manas.tech>  $(LC_ALL=en_US date --utc +'%a, %-d %b %Y %T UTC')
+-- Crystal Team <crystal@manas.tech>  $(LC_ALL=en_US date --utc +'%a, %-d %b %Y %T +0000')
 EOF
 echo > *.changes
 


### PR DESCRIPTION
The debian package builder for testing (and unstable) now requires the changelod signoff date to use an offset, not a zone name. `UTC` was invalid as per RFC 5322 but `GMT` is also invalid.