### PR TITLE
Add script to search/download all the build artifacts

### DIFF
--- a/processes/crystal-release.md
+++ b/processes/crystal-release.md
@@ -57,20 +57,22 @@ document. In this way it's easy to track the progress of the release (*Helper:
 
 ### Binary releases
 
-1. Publish build artifacts from CircleCI and GitHub Actions to GitHub release. For `URL_TO_CIRCLECI_ARTIFACT` grab the URL
-   of any of the build artifacts in circleCI (doesn't matter which).
-   * [ ] Upload build artifacts from CircleCI: (`crystal`) [`../distribution-scripts/processes/scripts/publish-crystal-packages-on-github.sh $URL_TO_CIRCLECI_ARTIFACT`](https://github.com/crystal-lang/distribution-scripts/blob/master/processes/scripts/publish-crystal-packages-on-github.sh) (run from `crystallang/crystal@${VERSION}` work tree)
+1. [ ] Download build artifacts from CircleCI and GitHub Actions: (`distribution-scripts`) [`./processes/scripts/download-crystal-release-artifacts.sh $VERSION`](https://github.com/crystal-lang/distribution-scripts/blob/master/processes/scripts/download-crystal-release-artifacts.sh). This performs these steps:
+   1. Search the release build from the latest CircleCI pipelines
+   2. Download build artifacts from the CircleCI jobs:
       * `crystal-*-darwin-*.tar.gz`
       * `crystal-*-linux-*.tar.gz`
       * `crystal-*.pkg`
       * `crystal-*-docs.tar.gz`
-   * [ ] Upload build artifacts from GHA (Windows):
-      * Windows CI: `crystal.zip` -> `crystal-${VERSION}-windows-x86_64-msvc-unsupported.zip`
-      * Windows CI: `crystal-installer.zip` -> unzip -> `crystal-${VERSION}-windows-x86_64-msvc-unsupported.exe`
-      * MinGW-w64 CI: `x86_64-mingw-w64-crystal.zip` -> `crystal-${VERSION}-windows-x86_64-gnu-unsupported.zip`
-      * MinGW-w64 CI: `aarch64-mingw-w64-crystal.zip` -> `crystal-${VERSION}-windows-aarch64-gnu-unsupported.zip`
-2. [ ] Publish the GitHub release
-3. [ ] Push changes to OBS for building linux packages
+   3. Search the release build in GitHub Actions
+   4. Download the artifacts from the CircleCI job (MinGW-w64 CI, Windows CI)
+   5. Compress and rename the GHA artifacts:
+      * Windows CI: `crystal/*` -> `crystal-${VERSION}-windows-x86_64-msvc-unsupported.zip`
+      * Windows CI: `crystal-installer/crystal-setup.exe` -> `crystal-${VERSION}-windows-x86_64-msvc-unsupported.exe`
+      * MinGW-w64 CI: `*-mingw-w64-crystal/*` -> `crystal-${VERSION}-windows-*-gnu-unsupported.zip`
+2. [ ] Upload build artifacts to the GitHub Release: (`distribution-scripts`) `gh release -R crystal-lang/crystal upload ${VERSION} crystal-${VERSION}*`
+3. [ ] Publish the GitHub release
+4. [ ] Push changes to OBS for building linux packages
    1. Checkout https://github.com/crystal-lang/distribution-scripts and go to [`./packages`](../packages)
    2. Configure build.opensuse.org credentials in environment variables:
       * `export OBS_USER=`
@@ -93,13 +95,13 @@ document. In this way it's easy to track the progress of the release (*Helper:
       * `crystal${VERSION%.*}`
    8. (optional) Verify package installation
       * (`distribution-scripts/packages`) `OBS_PROJECT=devel:languages:crystal bats test`
-4. [ ] Tag `latest` docker images
+5. [ ] Tag `latest` docker images
    * Versioned docker images have been pushed to Docker Hub.
    * Now just assign the `latest` tags:
    *  (`distribution-scripts`) `./docker/apply-latest-tags.sh ${VERSION}`
-5. [ ] Publish snap package
+6. [ ] Publish snap package
    - On https://snapcraft.io/crystal/releases promote the `latest/edge` release to `latest/beta` and then `latest/stable`
-6. [ ] Check PR for homebrew: https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+crystal+sort%3Aupdated-desc
+7. [ ] Check PR for homebrew: https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+crystal+sort%3Aupdated-desc
    * It should've been automatically created
 
 ### Publish documentation for the release

--- a/processes/scripts/download-crystal-release-artifacts.sh
+++ b/processes/scripts/download-crystal-release-artifacts.sh
@@ -21,7 +21,7 @@ for cmd in curl jq gh zip; do
 done
 
 if [ -z $1 ]; then
-  echo "Usage: ./download_artifacts.sh <version>"
+  echo "Usage: ./download-crystal-release-artifacts.sh <version>"
   exit 1
 fi
 

--- a/scripts/download_artifacts.sh
+++ b/scripts/download_artifacts.sh
@@ -44,12 +44,12 @@ GHA_MSVC_RUN_ID=$(gh run list -R crystal-lang/crystal --branch "$VERSION" --json
 
 echo "Downloading/compressing release artifacts from GitHub ..."
 gh run -R crystal-lang/crystal download "$GHA_MINGW_RUN_ID"
-sh -c "cd aarch64-mingw-w64-crystal/ && zip -9 -r '../crystal-$VERSION-$REV-windows-aarch64-gnu-unsupported.zip' *"
-sh -c "cd x86_64-mingw-w64-crystal/ && zip -9 -r '../crystal-$VERSION-$REV-windows-x86_64-gnu-unsupported.zip' *"
+sh -c "cd aarch64-mingw-w64-crystal/ && zip -9 -r '../crystal-$VERSION-windows-aarch64-gnu-unsupported.zip' *"
+sh -c "cd x86_64-mingw-w64-crystal/ && zip -9 -r '../crystal-$VERSION-windows-x86_64-gnu-unsupported.zip' *"
 
 gh run -R crystal-lang/crystal download "$GHA_MSVC_RUN_ID"
-sh -c "cd crystal/ && zip -9 -r '../crystal-$VERSION-$REV-windows-msvc-unsupported.zip' *"
-mv crystal-installer/crystal-setup.exe "crystal-$VERSION-$REV-windows-msvc-unsupported.exe"
+sh -c "cd crystal/ && zip -9 -r '../crystal-$VERSION-windows-x86_64-msvc-unsupported.zip' *"
+mv crystal-installer/crystal-setup.exe "crystal-$VERSION-windows-x86_64-msvc-unsupported.exe"
 
 echo "Final list of artifacts to upload:"
 echo crystal-$VERSION*

--- a/scripts/download_artifacts.sh
+++ b/scripts/download_artifacts.sh
@@ -1,0 +1,58 @@
+#! /usr/bin/env sh
+
+# Download release builds of Crystal.
+#
+# Searches the Linux and Darwin builds from CircleCI (recent builds only), and
+# Windows MSVC and MinGW builds from GHA. Prepares ZIP files for the GHA builds.
+#
+# Usage:
+#
+#     scripts/download_artifacts.sh <version>
+#
+# Requires `gh` with `GITHUB_TOKEN` environment variable or authenticated
+# through `gh auth login`.
+
+VERSION=$1
+REV=1
+SLUG=crystal-lang/crystal
+
+for cmd in curl jq gh zip; do
+  command -v $cmd > /dev/null || { echo "Command not found: $cmd"; exit 1; }
+done
+
+if [ -z $1 ]; then
+  echo "Usage: ./download_artifacts.sh <version>"
+  exit 1
+fi
+
+set -e
+
+echo "Searching release artifacts on CircleCI ..."
+PIPELINE_ID=$(curl -sSL "https://circleci.com/api/v2/project/gh/$SLUG/pipeline" | jq -r ".items[] | select(.vcs.tag == \"$VERSION\") | .id")
+WORKFLOW_ID=$(curl -sSL "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | jq -r '.items[0].id')
+JOB_NUMBER=$(curl -sSL "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" | jq -r '.items.[] | select(.name == "dist_artifacts") | .job_number')
+ARTIFACT_URLS=$(curl -sSL "https://circleci.com/api/v2/project/gh/$SLUG/$JOB_NUMBER/artifacts" | jq -r '.items.[] | select(.url | test(".tar.gz|.pkg")) | .url')
+
+echo "Downloading release artifacts from CircleCI ..."
+for artifact_url in $ARTIFACT_URLS; do
+  curl -LO "$artifact_url"
+done
+
+echo "Searching release artifacts on GitHub ..."
+GHA_MINGW_RUN_ID=$(gh run list -R crystal-lang/crystal --branch "$VERSION" --json databaseId,name --jq '.[] | select(.name | contains("MinGW-w64 CI")).databaseId')
+GHA_MSVC_RUN_ID=$(gh run list -R crystal-lang/crystal --branch "$VERSION" --json databaseId,name --jq '.[] | select(.name | contains("Windows CI")).databaseId')
+
+echo "Downloading/compressing release artifacts from GitHub ..."
+gh run -R crystal-lang/crystal download "$GHA_MINGW_RUN_ID"
+sh -c "cd aarch64-mingw-w64-crystal/ && zip -9 -r '../crystal-$VERSION-$REV-windows-aarch64-gnu-unsupported.zip' *"
+sh -c "cd x86_64-mingw-w64-crystal/ && zip -9 -r '../crystal-$VERSION-$REV-windows-x86_64-gnu-unsupported.zip' *"
+
+gh run -R crystal-lang/crystal download "$GHA_MSVC_RUN_ID"
+sh -c "cd crystal/ && zip -9 -r '../crystal-$VERSION-$REV-windows-msvc-unsupported.zip' *"
+mv crystal-installer/crystal-setup.exe "crystal-$VERSION-$REV-windows-msvc-unsupported.exe"
+
+echo "Final list of artifacts to upload:"
+echo crystal-$VERSION*
+
+echo "You can now upload artifacts to the GitHub release:"
+echo "gh release -R crystal-lang/crystal upload $VERSION crystal-$VERSION*"


### PR DESCRIPTION
The current script only downloads the CircleCI artifacts and requires a workflow id. This alternative _searches_ for the release workflow jobs on CircleCI and GHA, then downloads everything (linux, darwin, windows, docs) and handles gha/windows artifacts (compresses ZIP files, renames the build files).

Example usage:

```console
$ ./processes/scripts/download-crystal-release-artifacts 1.20.1
```

NOTE: We can't search by tag on CircleCI and I didn't implement pagination in bash. The release build must be a recent build to appear on the first page of latest pipelines.