### PR TITLE
CI: Switch to `bats-core/bats-action`

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup BATS
-        uses: mig4/setup-bats@v1
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           bats-version: 1.9.0
 


### PR DESCRIPTION
We're currently using https://github.com/mig4/setup-bats. It hasn't been updated in years and looks abandoned, and produces deprecation warnings for Node 20.
https://github.com/bats-core/bats-action is provided by the official bats org and seems to be actively maintained.

Ref crystal-lang/test-ecosystem#91