### PR TITLE
Improve test for static executable

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -61,7 +61,7 @@ RUN git clone ${crystal_repo} \
  \
  && make crystal stats=true static=true FLAGS=--link-flags=-no-pie ${release:+release=true} \
                  CRYSTAL_CONFIG_TARGET=${gnu_target} \
- && ( (readelf --program-headers .build/crystal | grep -q "Elf file type is EXEC") || { echo 'crystal is not statically linked'; exit 1; }) \
+ && ( ((! readelf --dynamic .build/crystal | grep -q NEEDED) && (! readelf --program-headers .build/crystal | grep -q INTERP)) || { echo 'crystal is not statically linked'; exit 1; }) \
  && .build/crystal --version
 
 # Build shards
@@ -74,7 +74,7 @@ RUN git clone https://github.com/crystal-lang/shards \
          FLAGS="--stats --target ${musl_target} --static --link-flags=-no-pie ${release:+--release}" \
  \
  && bin/shards --version \
- && ( (readelf --program-headers bin/shards | grep -q "Elf file type is EXEC") || { echo 'shards is not statically linked'; exit 1; })
+ && ( ((! readelf --dynamic bin/shards | grep -q NEEDED) && (! readelf --program-headers bin/shards | grep -q INTERP)) || { echo 'shards is not statically linked'; exit 1; })
 
 COPY --from=bdwgc /bdwgc/.libs/libgc.a /libgc-debian.a
 


### PR DESCRIPTION
`ldd` on alpine reports a dynamic dependency on `ld-musl` for static-pie executables. We cannot parse that output.
Instead, we explicitly check that the executable doesn't have any dynamic NEEDED libraries, and no ELF interpreter set.

This is an alternative fix for https://github.com/crystal-lang/distribution-scripts/issues/441 instead of #442.
See https://forum.crystal-lang.org/t/gcc-15-on-alpine-linux-changes-static-to-imply-pie-i-e-static-pie/9074/6?u=straight-shoota

We may still want to continue with `-no-pie` as a workaround for #445.